### PR TITLE
Import reviewed Ruby and Rails Cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -8,3 +8,278 @@ GitHub/ApplicationRecord:
 
 Style/TrailingWhitespace:
   Enabled: true
+
+Lint/BlockAlignment:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Lint/ConditionPosition:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DefEndAlignment:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndAlignment:
+  Enabled: false
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/Eval:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/InvalidCharacterLiteral:
+  Enabled: true
+
+Lint/LiteralInCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Enabled: true
+
+Lint/RandOne:
+  Enabled: true
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnneededDisable:
+  Enabled: true
+
+Lint/UnneededSplatExpansion:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Performance/CaseWhenSplat:
+  Enabled: false
+
+Performance/Count:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/DoubleStartEndWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/HashEachMethods:
+  Enabled: true
+
+Performance/LstripRstrip:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: false
+
+Performance/RedundantMatch:
+  Enabled: false
+
+Performance/RedundantMerge:
+  Enabled: true
+  MaxKeyValuePairs: 1
+
+Performance/RedundantSortBy:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/Sample:
+  Enabled: true
+
+Performance/Size:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Style/ArrayJoin:
+  Enabled: true
+
+Style/AsciiIdentifiers:
+  Enabled: true
+
+Style/BeginBlock:
+  Enabled: true
+
+Style/BlockComments:
+  Enabled: true
+
+Style/BlockEndNewline:
+  Enabled: true
+
+Style/CaseEquality:
+  Enabled: true
+
+Style/CharacterLiteral:
+  Enabled: true
+
+Style/ClassAndModuleCamelCase:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+Style/EndBlock:
+  Enabled: true
+
+Style/EndOfLine:
+  Enabled: true
+
+Style/FileName:
+  Enabled: true
+
+Style/FlipFlop:
+  Enabled: true
+
+Style/For:
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/InitialIndentation:
+  Enabled: true
+
+Style/LambdaCall:
+  Enabled: true
+
+Style/MethodCallParentheses:
+  Enabled: true
+
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/MethodName:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/NilComparison:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Style/SpaceAfterMethodName:
+  Enabled: true
+
+Style/SpaceAfterColon:
+  Enabled: true
+
+Style/SpaceAfterComma:
+  Enabled: true
+
+Style/SpaceAfterNot:
+  Enabled: true
+
+Style/SpaceAfterSemicolon:
+  Enabled: true
+
+Style/SpaceAroundBlockParameters:
+  Enabled: true
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Style/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Style/SpaceInsideBrackets:
+  Enabled: true
+
+Style/SpaceInsideParens:
+  Enabled: true
+
+Style/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Style/StabbyLambdaParentheses:
+  Enabled: true
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/Tab:
+  Enabled: true
+
+Style/TrailingBlankLines:
+  Enabled: true
+
+Style/TrailingWhitespace:
+  Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,9 +3,6 @@ require: rubocop/cop/github
 AllCops:
   DisabledByDefault: true
 
-GitHub/ApplicationRecord:
-  Enabled: true
-
 Lint/BlockAlignment:
   Enabled: true
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,9 +6,6 @@ AllCops:
 GitHub/ApplicationRecord:
   Enabled: true
 
-Style/TrailingWhitespace:
-  Enabled: true
-
 Lint/BlockAlignment:
   Enabled: true
 

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -19,3 +19,6 @@ Rails/ScopeArgs:
 
 Rails/UniqBeforePluck:
   Enabled: true
+
+GitHub/ApplicationRecord:
+  Enabled: true

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -20,5 +20,5 @@ Rails/ScopeArgs:
 Rails/UniqBeforePluck:
   Enabled: true
 
-GitHub/ApplicationRecord:
+GitHub/RailsApplicationRecord:
   Enabled: true

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,0 +1,21 @@
+Rails:
+  Enabled: true
+
+Rails/FindEach:
+  Enabled: false
+
+Rails/OutputSafety:
+  Enabled: true
+
+Rails/PluralizationGrammar:
+  Enabled: true
+
+Rails/RequestReferer:
+  Enabled: true
+  EnforcedStyle: referrer
+
+Rails/ScopeArgs:
+  Enabled: true
+
+Rails/UniqBeforePluck:
+  Enabled: true

--- a/lib/rubocop/cop/github.rb
+++ b/lib/rubocop/cop/github.rb
@@ -1,1 +1,1 @@
-require "rubocop/cop/github/application_record"
+require "rubocop/cop/github/rails_application_record"

--- a/lib/rubocop/cop/github/rails_application_record.rb
+++ b/lib/rubocop/cop/github/rails_application_record.rb
@@ -3,7 +3,7 @@ require "rubocop"
 module RuboCop
   module Cop
     module GitHub
-      class ApplicationRecord < Cop
+      class RailsApplicationRecord < Cop
         MSG = "Models should subclass from ApplicationRecord"
 
         ACTIVE_RECORD_BASE = s(:const, s(:const, nil, :ActiveRecord), :Base)

--- a/test/test_rails_application_record.rb
+++ b/test/test_rails_application_record.rb
@@ -1,10 +1,10 @@
-require "rubocop/cop/github/application_record"
+require "rubocop/cop/github/rails_application_record"
 require "minitest/autorun"
 
-class TestApplicationRecord < MiniTest::Test
+class TestRailsApplicationRecord < MiniTest::Test
   def setup
     config = RuboCop::Config.new
-    @cop = RuboCop::Cop::GitHub::ApplicationRecord.new(config)
+    @cop = RuboCop::Cop::GitHub::RailsApplicationRecord.new(config)
   end
 
   def test_good_model


### PR DESCRIPTION
Imports cops currently used internally by GitHub. Separates out Rails specific cops so pure Ruby projects don't need to enable them along with the default config.

##

CC: @tma 