### PR TITLE
Use node matcher

### DIFF
--- a/lib/rubocop/cop/github/rails_application_record.rb
+++ b/lib/rubocop/cop/github/rails_application_record.rb
@@ -6,12 +6,18 @@ module RuboCop
       class RailsApplicationRecord < Cop
         MSG = "Models should subclass from ApplicationRecord"
 
-        ACTIVE_RECORD_BASE = s(:const, s(:const, nil, :ActiveRecord), :Base)
+        def_node_matcher :active_record_base_const?, <<-PATTERN
+          (const (const nil :ActiveRecord) :Base)
+        PATTERN
+
+        def_node_matcher :application_record_const?, <<-PATTERN
+          (const nil :ApplicationRecord)
+        PATTERN
 
         def on_class(node)
-          name, superclass, _body = *node
+          klass, superclass, _ = *node
 
-          if superclass == ACTIVE_RECORD_BASE && !(name.const_name == "ApplicationRecord")
+          if active_record_base_const?(superclass) && !(application_record_const?(klass))
             add_offense(superclass, :expression)
           end
         end


### PR DESCRIPTION
I'd prefer to use `def_node_matcher` which provides by rubocop.

WDYT?

Related: https://github.com/github/rubocop-github/pull/3