### PR TITLE
Change department from Style to Layout

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -206,7 +206,7 @@ Style/BeginBlock:
 Style/BlockComments:
   Enabled: true
 
-Style/BlockEndNewline:
+Layout/BlockEndNewline:
   Enabled: true
 
 Style/CaseEquality:
@@ -230,7 +230,7 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
-Style/EndOfLine:
+Layout/EndOfLine:
   Enabled: true
 
 Style/FileName:
@@ -245,7 +245,7 @@ Style/For:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
-Style/InitialIndentation:
+Layout/InitialIndentation:
   Enabled: true
 
 Style/LambdaCall:
@@ -272,37 +272,37 @@ Style/Not:
 Style/OneLineConditional:
   Enabled: true
 
-Style/SpaceAfterMethodName:
+Layout/SpaceAfterMethodName:
   Enabled: true
 
-Style/SpaceAfterColon:
+Layout/SpaceAfterColon:
   Enabled: true
 
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Enabled: true
 
-Style/SpaceAfterNot:
+Layout/SpaceAfterNot:
   Enabled: true
 
-Style/SpaceAfterSemicolon:
+Layout/SpaceAfterSemicolon:
   Enabled: true
 
-Style/SpaceAroundBlockParameters:
+Layout/SpaceAroundBlockParameters:
   Enabled: true
 
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
-Style/SpaceInsideArrayPercentLiteral:
+Layout/SpaceInsideArrayPercentLiteral:
   Enabled: true
 
-Style/SpaceInsideBrackets:
+Layout/SpaceInsideBrackets:
   Enabled: true
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: true
 
-Style/SpaceInsideRangeLiteral:
+Layout/SpaceInsideRangeLiteral:
   Enabled: true
 
 Style/StabbyLambdaParentheses:
@@ -312,11 +312,11 @@ Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
 
-Style/Tab:
+Layout/Tab:
   Enabled: true
 
-Style/TrailingBlankLines:
+Layout/TrailingBlankLines:
   Enabled: true
 
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Enabled: true

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -101,7 +101,7 @@ Style/Semicolon:
   Exclude:
     - 'app/views/**/*.erb'
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Exclude:
     - 'app/views/**/*.erb'
 
@@ -109,10 +109,10 @@ Style/StringLiterals:
   Exclude:
     - 'app/views/**/*.erb'
 
-Style/TrailingBlankLines:
+Layout/TrailingBlankLines:
   Exclude:
     - 'app/views/**/*.erb'
 
-Style/TrailingWhitespace:
+Layout/TrailingWhitespace:
   Exclude:
     - 'app/views/**/*.erb'

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"
   s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "erubis", "~> 2.7"
 
   s.required_ruby_version = ">= 2.1.0"
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.47"
+  s.add_dependency "rubocop", "~> 0.49"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
All cops dealing with whitespace into a new department called `Layout` after Rubocop 0.49.0, which was introduced in https://github.com/bbatsov/rubocop/pull/4278

This PR will clear the warnings.

### before
```
$ bundle exec rubocop
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/BlockEndNewline has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/EndOfLine has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/InitialIndentation has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAfterMethodName has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAfterColon has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAfterComma has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAfterNot has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAfterSemicolon has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAroundBlockParameters has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceAroundEqualsInParameterDefault has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceInsideArrayPercentLiteral has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceInsideBrackets has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceInsideParens has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/SpaceInsideRangeLiteral has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/Tab has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/default.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/rails.yml: Style/SpaceInsideParens has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/rails.yml: Style/TrailingBlankLines has the wrong namespace - should be Layout
/Users/tetsuya/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rubocop-github-0.4.2/config/rails.yml: Style/TrailingWhitespace has the wrong namespace - should be Layout
Inspecting 41 files
.........................................

41 files inspected, no offenses detected
```

### after
```
$ bundle exec rubocop
Inspecting 41 files
.........................................

41 files inspected, no offenses detected
```