### PR TITLE
Fix naming cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -197,7 +197,7 @@ Security/Eval:
 Style/ArrayJoin:
   Enabled: true
 
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Enabled: true
 
 Style/BeginBlock:
@@ -215,7 +215,7 @@ Style/CaseEquality:
 Style/CharacterLiteral:
   Enabled: true
 
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Enabled: true
 
 Style/ClassMethods:
@@ -233,7 +233,7 @@ Style/EndBlock:
 Layout/EndOfLine:
   Enabled: true
 
-Style/FileName:
+Naming/FileName:
   Enabled: true
 
 Style/FlipFlop:
@@ -257,7 +257,7 @@ Style/MethodCallWithoutArgsParentheses:
 Style/MethodDefParentheses:
   Enabled: true
 
-Style/MethodName:
+Naming/MethodName:
   Enabled: true
 
 Style/MultilineIfThen:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.49"
+  s.add_dependency "rubocop", "~> 0.50"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
These Style cops have been moved to Naming in the most recent version.
I've also bumped the dependency.

:raised_hands:

Signed-off-by: David Calavera <david.calavera@gmail.com>