### PR TITLE
Set rubocop dependency version to < 0.51.0

### DIFF
--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.49"
+  s.add_dependency "rubocop", [">= 0.49.0", "< 0.51.0"]
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
Rubocop release 0.51.0 introduced breaking changes that prevent the rubocop-github config from working out-of-the-box. Pin the dependency until the configuration can be updated.

```
Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered.
(obsolete configuration found in /gems/rubocop-github-0.5.0/config/default.yml, please update it)
```

I played around with making adjusting the lints like https://github.com/github/rubocop-github/pull/15, but the update to rubocop also makes many tests fail on v0.51.0.

I might try to fix this in a subsequent pull request, but by pinning the dependency at least things won't fail from a clean `bundle install`.