### PR TITLE
Fixes for Rubocop v0.51.0

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -64,9 +64,6 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
 
-Lint/InvalidCharacterLiteral:
-  Enabled: true
-
 Lint/LiteralInCondition:
   Enabled: true
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -64,7 +64,7 @@ Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Enabled: true
 
 Lint/LiteralInInterpolation:

--- a/config/default.yml
+++ b/config/default.yml
@@ -194,7 +194,7 @@ Security/Eval:
 Style/ArrayJoin:
   Enabled: true
 
-Style/AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Enabled: true
 
 Style/BeginBlock:
@@ -212,7 +212,7 @@ Style/CaseEquality:
 Style/CharacterLiteral:
   Enabled: true
 
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Enabled: true
 
 Style/ClassMethods:
@@ -230,7 +230,7 @@ Style/EndBlock:
 Layout/EndOfLine:
   Enabled: true
 
-Style/FileName:
+Naming/FileName:
   Enabled: true
 
 Style/FlipFlop:
@@ -254,7 +254,7 @@ Style/MethodCallWithoutArgsParentheses:
 Style/MethodDefParentheses:
   Enabled: true
 
-Style/MethodName:
+Naming/MethodName:
   Enabled: true
 
 Style/MultilineIfThen:

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,6 +9,57 @@ Bundler/DuplicatedGem:
 Bundler/OrderedGems:
   Enabled: true
 
+Layout/BlockEndNewline:
+  Enabled: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundBlockParameters:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsideBrackets:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingBlankLines:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
 Lint/BlockAlignment:
   Enabled: true
 
@@ -42,14 +93,14 @@ Lint/ElseLayout:
 Lint/EmptyEnsure:
   Enabled: true
 
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EmptyInterpolation:
   Enabled: true
 
 Lint/EndAlignment:
   Enabled: false
+
+Lint/EndInMethod:
+  Enabled: true
 
 Lint/EnsureReturn:
   Enabled: true
@@ -59,10 +110,6 @@ Lint/FloatOutOfRange:
 
 Lint/FormatParameterMismatch:
   Enabled: true
-
-Style/HashSyntax:
-  Enabled: true
-  EnforcedStyle: ruby19
 
 Lint/LiteralAsCondition:
   Enabled: true
@@ -139,6 +186,18 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/AsciiIdentifiers:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Naming/FileName:
+  Enabled: true
+
+Naming/MethodName:
+  Enabled: true
+
 Performance/CaseWhenSplat:
   Enabled: false
 
@@ -194,25 +253,16 @@ Security/Eval:
 Style/ArrayJoin:
   Enabled: true
 
-Naming/AsciiIdentifiers:
-  Enabled: true
-
 Style/BeginBlock:
   Enabled: true
 
 Style/BlockComments:
   Enabled: true
 
-Layout/BlockEndNewline:
-  Enabled: true
-
 Style/CaseEquality:
   Enabled: true
 
 Style/CharacterLiteral:
-  Enabled: true
-
-Naming/ClassAndModuleCamelCase:
   Enabled: true
 
 Style/ClassMethods:
@@ -227,12 +277,6 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
-Layout/EndOfLine:
-  Enabled: true
-
-Naming/FileName:
-  Enabled: true
-
 Style/FlipFlop:
   Enabled: true
 
@@ -242,8 +286,9 @@ Style/For:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
-Layout/InitialIndentation:
+Style/HashSyntax:
   Enabled: true
+  EnforcedStyle: ruby19
 
 Style/LambdaCall:
   Enabled: true
@@ -252,9 +297,6 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
-  Enabled: true
-
-Naming/MethodName:
   Enabled: true
 
 Style/MultilineIfThen:
@@ -269,51 +311,9 @@ Style/Not:
 Style/OneLineConditional:
   Enabled: true
 
-Layout/SpaceAfterMethodName:
-  Enabled: true
-
-Layout/SpaceAfterColon:
-  Enabled: true
-
-Layout/SpaceAfterComma:
-  Enabled: true
-
-Layout/SpaceAfterNot:
-  Enabled: true
-
-Layout/SpaceAfterSemicolon:
-  Enabled: true
-
-Layout/SpaceAroundBlockParameters:
-  Enabled: true
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Layout/SpaceInsideArrayPercentLiteral:
-  Enabled: true
-
-Layout/SpaceInsideBrackets:
-  Enabled: true
-
-Layout/SpaceInsideParens:
-  Enabled: true
-
-Layout/SpaceInsideRangeLiteral:
-  Enabled: true
-
 Style/StabbyLambdaParentheses:
   Enabled: true
 
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/Tab:
-  Enabled: true
-
-Layout/TrailingBlankLines:
-  Enabled: true
-
-Layout/TrailingWhitespace:
-  Enabled: true

--- a/lib/rubocop/cop/github/rails_application_record.rb
+++ b/lib/rubocop/cop/github/rails_application_record.rb
@@ -9,18 +9,18 @@ module RuboCop
         MSG = "Models should subclass from ApplicationRecord"
 
         def_node_matcher :active_record_base_const?, <<-PATTERN
-          (const (const nil :ActiveRecord) :Base)
+          (const (const nil? :ActiveRecord) :Base)
         PATTERN
 
         def_node_matcher :application_record_const?, <<-PATTERN
-          (const nil :ApplicationRecord)
+          (const nil? :ApplicationRecord)
         PATTERN
 
         def on_class(node)
           klass, superclass, _ = *node
 
           if active_record_base_const?(superclass) && !(application_record_const?(klass))
-            add_offense(superclass, :expression)
+            add_offense(superclass, location: :expression)
           end
         end
       end

--- a/lib/rubocop/cop/github/rails_controller_render_action_symbol.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_action_symbol.rb
@@ -9,11 +9,11 @@ module RuboCop
         MSG = "Prefer `render` with string instead of symbol"
 
         def_node_matcher :render_sym?, <<-PATTERN
-          (send nil :render $(sym _))
+          (send nil? :render $(sym _))
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :action_key?, <<-PATTERN
@@ -22,11 +22,11 @@ module RuboCop
 
         def on_send(node)
           if sym_node = render_sym?(node)
-            add_offense(sym_node, :expression)
+            add_offense(sym_node, location: :expression)
           elsif option_pairs = render_with_options?(node)
             option_pairs.each do |pair|
               if sym_node = action_key?(pair)
-                add_offense(sym_node, :expression)
+                add_offense(sym_node, location: :expression)
               end
             end
           end

--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -9,19 +9,19 @@ module RuboCop
         MSG = "render must be used with a string literal"
 
         def_node_matcher :literal?, <<-PATTERN
-          ({str sym true false nil} ...)
+          ({str sym true false nil?} ...)
         PATTERN
 
         def_node_matcher :render?, <<-PATTERN
-          (send nil :render ...)
+          (send nil? :render ...)
         PATTERN
 
         def_node_matcher :render_literal?, <<-PATTERN
-          (send nil :render ({str sym} $_) $...)
+          (send nil? :render ({str sym} $_) $...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :ignore_key?, <<-PATTERN
@@ -73,19 +73,19 @@ module RuboCop
 
             if template_node = option_pairs.map { |pair| template_key?(pair) }.compact.first
               if !literal?(template_node)
-                add_offense(node, :expression)
+                add_offense(node, location: :expression)
               end
             else
-              add_offense(node, :expression)
+              add_offense(node, location: :expression)
             end
 
             if layout_node = option_pairs.map { |pair| layout_key?(pair) }.compact.first
               if !literal?(layout_node)
-                add_offense(node, :expression)
+                add_offense(node, location: :expression)
               end
             end
           else
-            add_offense(node, :expression)
+            add_offense(node, location: :expression)
           end
         end
       end

--- a/lib/rubocop/cop/github/rails_controller_render_paths_exist.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_paths_exist.rb
@@ -7,15 +7,15 @@ module RuboCop
     module GitHub
       class RailsControllerRenderPathsExist < Cop
         def_node_matcher :render?, <<-PATTERN
-          (send nil :render $...)
+          (send nil? :render $...)
         PATTERN
 
         def_node_matcher :render_str?, <<-PATTERN
-          (send nil :render $({str sym} $_) ...)
+          (send nil? :render $({str sym} $_) ...)
         PATTERN
 
         def_node_matcher :render_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :render_key?, <<-PATTERN
@@ -28,7 +28,7 @@ module RuboCop
           if args = render_str?(node)
             node, path = args
             unless resolve_template(path.to_s)
-              add_offense(node, :expression, "Template could not be found")
+              add_offense(node, location: :expression, message: "Template could not be found")
             end
           elsif pairs = render_options?(node)
             if pair = pairs.detect { |p| render_key?(p) }
@@ -37,11 +37,11 @@ module RuboCop
               case key
               when :action, :template
                 unless resolve_template(path.to_s)
-                  add_offense(node, :expression, "Template could not be found")
+                  add_offense(node, location: :expression, message: "Template could not be found")
                 end
               when :partial
                 unless resolve_partial(path.to_s)
-                  add_offense(node, :expression, "Partial template could not be found")
+                  add_offense(node, location: :expression, message: "Partial template could not be found")
                 end
               end
             end

--- a/lib/rubocop/cop/github/rails_controller_render_shorthand.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_shorthand.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = "Prefer `render` template shorthand"
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :action_key?, <<-PATTERN
@@ -40,7 +40,7 @@ module RuboCop
                 @autocorrect[node] = lambda do |corrector|
                   corrector.replace(node.source_range, corrected_source)
                 end
-                add_offense(node, :expression, "Use `#{corrected_source}` instead")
+                add_offense(node, location: :expression, message: "Use `#{corrected_source}` instead")
               end
             end
           end

--- a/lib/rubocop/cop/github/rails_render_inline.rb
+++ b/lib/rubocop/cop/github/rails_render_inline.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = "Avoid `render inline:`"
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :inline_key?, <<-PATTERN
@@ -19,7 +19,7 @@ module RuboCop
         def on_send(node)
           if option_pairs = render_with_options?(node)
             if option_pairs.detect { |pair| inline_key?(pair) }
-              add_offense(node, :expression)
+              add_offense(node, location: :expression)
             end
           end
         end

--- a/lib/rubocop/cop/github/rails_render_object_collection.rb
+++ b/lib/rubocop/cop/github/rails_render_object_collection.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = "Avoid `render object:`"
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...) ...)
+          (send nil? :render (hash $...) ...)
         PATTERN
 
         def_node_matcher :partial_key?, <<-PATTERN
@@ -34,9 +34,9 @@ module RuboCop
                 if partial_name.children[0].is_a?(String)
                   suggestion = ", instead `render partial: #{partial_name.source}, locals: { #{File.basename(partial_name.children[0], '.html.erb')}: #{object_node.source} }`"
                 end
-                add_offense(node, :expression, "Avoid `render object:`#{suggestion}")
+                add_offense(node, location: :expression, message: "Avoid `render object:`#{suggestion}")
               when :collection, :spacer_template
-                add_offense(node, :expression, "Avoid `render collection:`")
+                add_offense(node, location: :expression, message: "Avoid `render collection:`")
               end
             end
           end

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -9,19 +9,19 @@ module RuboCop
         MSG = "render must be used with a string literal"
 
         def_node_matcher :literal?, <<-PATTERN
-          ({str sym true false nil} ...)
+          ({str sym true false nil?} ...)
         PATTERN
 
         def_node_matcher :render?, <<-PATTERN
-          (send nil :render $...)
+          (send nil? :render $...)
         PATTERN
 
         def_node_matcher :render_literal?, <<-PATTERN
-          (send nil :render ({str sym} $_) $...)
+          (send nil? :render ({str sym} $_) $...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...) ...)
+          (send nil? :render (hash $...) ...)
         PATTERN
 
         def_node_matcher :ignore_key?, <<-PATTERN
@@ -49,13 +49,13 @@ module RuboCop
 
             if partial_node = option_pairs.map { |pair| partial_key?(pair) }.compact.first
               if !literal?(partial_node)
-                add_offense(node, :expression)
+                add_offense(node, location: :expression)
               end
             else
-              add_offense(node, :expression)
+              add_offense(node, location: :expression)
             end
           else
-            add_offense(node, :expression)
+            add_offense(node, location: :expression)
           end
         end
       end

--- a/lib/rubocop/cop/github/rails_view_render_paths_exist.rb
+++ b/lib/rubocop/cop/github/rails_view_render_paths_exist.rb
@@ -7,15 +7,15 @@ module RuboCop
     module GitHub
       class RailsViewRenderPathsExist < Cop
         def_node_matcher :render?, <<-PATTERN
-          (send nil :render $...)
+          (send nil? :render $...)
         PATTERN
 
         def_node_matcher :render_str?, <<-PATTERN
-          (send nil :render $(str $_) ...)
+          (send nil? :render $(str $_) ...)
         PATTERN
 
         def_node_matcher :render_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :partial_key?, <<-PATTERN
@@ -28,14 +28,14 @@ module RuboCop
           if args = render_str?(node)
             node, path = args
             unless resolve_partial(path.to_s)
-              add_offense(node, :expression, "Partial template could not be found")
+              add_offense(node, location: :expression, message: "Partial template could not be found")
             end
           elsif pairs = render_options?(node)
             if pair = pairs.detect { |p| partial_key?(p) }
               node, path = partial_key?(pair)
 
               unless resolve_partial(path.to_s)
-                add_offense(node, :expression, "Partial template could not be found")
+                add_offense(node, location: :expression, message: "Partial template could not be found")
               end
             end
           end

--- a/lib/rubocop/cop/github/rails_view_render_shorthand.rb
+++ b/lib/rubocop/cop/github/rails_view_render_shorthand.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = "Prefer `render` partial shorthand"
 
         def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil :render (hash $...))
+          (send nil? :render (hash $...))
         PATTERN
 
         def_node_matcher :partial_key?, <<-PATTERN
@@ -26,9 +26,9 @@ module RuboCop
             locals_key = option_pairs.map { |pair| locals_key?(pair) }.compact.first
 
             if option_pairs.length == 1 && partial_key
-              add_offense(node, :expression, "Use `render #{partial_key.source}` instead")
+              add_offense(node, location: :expression, message: "Use `render #{partial_key.source}` instead")
             elsif option_pairs.length == 2 && partial_key && locals_key
-              add_offense(node, :expression, "Use `render #{partial_key.source}, #{locals_key.source}` instead")
+              add_offense(node, location: :expression, message: "Use `render #{partial_key.source}, #{locals_key.source}` instead")
             end
           end
         end

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.49"
+  s.add_dependency "rubocop", "~> 0.51.0"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
Rubocop v0.51.0 introduced some breaking API changes, this PR addresses those issues and bumps the gemspec to require the new version.

* Specify `~> 0.51.0` in the gemspec to bump dependency to only accept patch releases of Rubocop v0.51.
* Update cops to match new Rubocop APIs
  * The API for rubocop has changed and is expecting `nil?` instead of `nil` for node matchers. Update all instances to `nil?`.
  * The API for `add_offense` has been updated to use named parameters. Update callers to match and not raise warnings.
* Remove cop for `Lint/InvalidCharacterLiteral`, no longer supported in v0.51.0

Alternative to https://github.com/github/rubocop-github/pull/16.