### PR TITLE
Enable Layout/SpaceBeforeBlockBraces and Layout/SpaceInsideBlockBraces cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -39,7 +39,13 @@ Layout/SpaceAroundBlockParameters:
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
 Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsideBlockBraces:
   Enabled: true
 
 Layout/SpaceInsideBrackets:


### PR DESCRIPTION
While working on a PR in `github/github` I made a mistake of not including a space between my block braces. @gjtorikian pointed out this mistake, but then we realized the cops for this aren't enabled.

> * Use spaces around operators, after commas, colons and semicolons, around `{`
>   and before `}`.
> 
> ``` ruby
> sum = 1 + 2
> a, b = 1, 2
> 1 > 2 ? true : false; puts "Hi"
> [1, 2, 3].each { |e| puts e }
> ```

At the moment, we don't enforce this part: `.each { |e| puts e }`.

Enabling `Layout/SpaceBeforeBlockBraces` will add these rules:

```ruby
# bad
foo.map{ |a|
  a.bar.to_s
}

# good
foo.map { |a|
  a.bar.to_s
}
```

Enabling `Layout/SpaceInsideBlockBraces` will add these rules:

```ruby
# bad
some_array.each {puts e}

# good
some_array.each { puts e }

# bad
some_array.each {   }

# good
some_array.each {}

# bad
[1, 2, 3].each {|n| n * 2 }

# good
[1, 2, 3].each { |n| n * 2 }
```

As you might suspect, enabling these two rules causes a _lot_ violations, but they can be auto-corrected.

A sample report for `github/github`:

```
$ bin/rubocop app lib
Inspecting 4784 files

...

4784 files inspected, 831 offenses detected
```

Not sure how we usually proceed in this case, do we care about the `git blame` of these lines?