### PR TITLE
Update rubocop v0.52.0 - Remove SpaceInsideBrackets

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -42,7 +42,10 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Layout/SpaceInsideArrayPercentLiteral:
   Enabled: true
 
-Layout/SpaceInsideBrackets:
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+  
+Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 
 Layout/SpaceInsideParens:


### PR DESCRIPTION
Update with SpaceInsideArrayLiteralBrackets & SpaceInsideReferenceBrackets
per PR in v0.52.0 

- Change Log: https://github.com/bbatsov/rubocop/releases/tag/v0.52.0
- Issue: https://github.com/bbatsov/rubocop/issues/4811
- PR: https://github.com/bbatsov/rubocop/pull/5149