### PR TITLE
Don't allow mixed hashes

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -298,7 +298,7 @@ Style/FrozenStringLiteralComment:
 
 Style/HashSyntax:
   Enabled: true
-  EnforcedStyle: ruby19
+  EnforcedStyle: ruby19_no_mixed_keys
 
 Style/LambdaCall:
   Enabled: true


### PR DESCRIPTION
As per the [STYLEGUIDE](https://github.com/github/rubocop-github/blob/dc78d6add4d5419f7b8544aa6b105b443c9e8876/STYLEGUIDE.md#hashes), we don't want hashes with mixed ruby19 and hash rocket syntax. This adjusts the Rubocop rules to fall more inline with that.