### PR TITLE
Fix warnings when using rubocop 0.53.0

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -148,7 +148,7 @@ Lint/StringConversionInInterpolation:
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Enabled: true
 
 Lint/UnneededSplatExpansion:

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -85,7 +85,7 @@ GitHub/RailsViewRenderShorthand:
 
 # Exclude Rails ERB files from incompatible cops
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Exclude:
     - 'app/views/**/*.erb'
 


### PR DESCRIPTION
Fix the warnings bellow:
`unrecognized cop Lint/UnneededDisable found in .rubocop.yml`
`Lint/BlockAlignment has the wrong namespace - should be Layout`