### PR TITLE
Update tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,6 @@
 inherit_from: ./config/default.yml
+
+Naming/FileName:
+  Enabled: true
+  Exclude:
+    - "rubocop-github.gemspec"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RuboCop GitHub
+# RuboCop GitHub [![Build Status](https://travis-ci.org/github/rubocop-github.svg?branch=master)](https://travis-ci.org/github/rubocop-github)
 
 This repository provides recommended RuboCop configuration and additional Cops for use on GitHub open source and internal Ruby projects.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"

--- a/lib/rubocop/cop/github.rb
+++ b/lib/rubocop/cop/github.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubocop/cop/github/rails_application_record"
 require "rubocop/cop/github/rails_controller_render_action_symbol"
 require "rubocop/cop/github/rails_controller_render_literal"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name = "rubocop-github"
   s.version = "0.10.0"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"
   s.add_development_dependency "rake", "~> 12.0"
-  s.add_development_dependency "erubis", "~> 2.7"
 
   s.required_ruby_version = ">= 2.1.0"
 

--- a/test/cop_test.rb
+++ b/test/cop_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_view"
 require "minitest"
 

--- a/test/cop_test.rb
+++ b/test/cop_test.rb
@@ -21,7 +21,7 @@ class CopTest < MiniTest::Test
   end
 
   def erb_investigate(cop, src, filename = nil)
-    engine = ActionView::Template::Handlers::Erubis.new(src)
-    investigate(cop, engine.src, filename)
+    engine = ActionView::Template::Handlers::ERB::Erubi.new(src)
+    investigate(cop, engine.src.dup, filename)
   end
 end


### PR DESCRIPTION
It looks like a recent Rails version removed ActionView::Template::Handlers::Erubis, causing our tests to fail [on master](https://travis-ci.org/github/rubocop-github/jobs/350822896). 

This PR gets CI passing again by updating our tests and fixing failing cops. Then, it adds a badge to the readme (at first, I thought we didn't run CI, but then I found links to it in PRs). Does it look OK?