### PR TITLE
Rename outdated cops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 
+git:
+  depth: 10
+
 rvm:
   - 2.3.6
   - 2.4.3

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,20 +9,8 @@ Bundler/DuplicatedGem:
 Bundler/OrderedGems:
   Enabled: true
 
-Layout/BlockAlignment:
-  Enabled: true
-
 Layout/BlockEndNewline:
   Enabled: true
-
-Layout/ConditionPosition:
-  Enabled: true
-
-Layout/DefEndAlignment:
-  Enabled: true
-
-Layout/EndAlignment:
-  Enabled: false
 
 Layout/EndOfLine:
   Enabled: true
@@ -82,10 +70,19 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/BlockAlignment:
+  Enabled: true
+
 Lint/CircularArgumentReference:
   Enabled: true
 
+Lint/ConditionPosition:
+  Enabled: true
+
 Lint/Debugger:
+  Enabled: true
+
+Lint/DefEndAlignment:
   Enabled: true
 
 Lint/DeprecatedClassMethods:
@@ -108,6 +105,9 @@ Lint/EmptyEnsure:
 
 Lint/EmptyInterpolation:
   Enabled: true
+
+Lint/EndAlignment:
+  Enabled: false
 
 Lint/EndInMethod:
   Enabled: true

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -85,7 +85,7 @@ GitHub/RailsViewRenderShorthand:
 
 # Exclude Rails ERB files from incompatible cops
 
-Layout/BlockAlignment:
+Lint/BlockAlignment:
   Exclude:
     - 'app/views/**/*.erb'
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.51"
+  s.add_dependency "rubocop", "~> 0.59"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
This gem no longer works for newer Rubocop versions:

```
Error running RuboCop Error: vendor/gems/2.5.2/ruby/2.5.0/gems/rubocop-github-0.10.0/config/default.yml: Layout/BlockAlignment has the wrong namespace - should be Lint
vendor/gems/2.5.2/ruby/2.5.0/gems/rubocop-github-0.10.0/config/default.yml: Layout/ConditionPosition has the wrong namespace - should be Lint
vendor/gems/2.5.2/ruby/2.5.0/gems/rubocop-github-0.10.0/config/default.yml: Layout/DefEndAlignment has the wrong namespace - should be Lint
vendor/gems/2.5.2/ruby/2.5.0/gems/rubocop-github-0.10.0/config/default.yml: Layout/EndAlignment has the wrong namespace - should be Lint
vendor/gems/2.5.2/ruby/2.5.0/gems/rubocop-github-0.10.0/config/rails.yml: Layout/BlockAlignment has the wrong namespace - should be Lint
```

I've renamed the renamed cops, but surprisingly, there's an Erubis issue as well that I haven't dug into yet.