### PR TITLE
Move `FlipFlop` cop from `Style` to `Lint` department

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -115,6 +115,9 @@ Lint/EndInMethod:
 Lint/EnsureReturn:
   Enabled: true
 
+Lint/FlipFlop:
+  Enabled: true
+
 Lint/FloatOutOfRange:
   Enabled: true
 
@@ -282,9 +285,6 @@ Style/DefWithParentheses:
   Enabled: true
 
 Style/EndBlock:
-  Enabled: true
-
-Style/FlipFlop:
   Enabled: true
 
 Style/For:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.59"
+  s.add_dependency "rubocop", "~> 0.63"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
Rubocop 0.63.0 moved Style/FlipFlop to Lint/FlipFlop.
Ref: https://github.com/rubocop-hq/rubocop/pull/6636

This updates the config and locks rubocop to ~> 0.63.