### PR TITLE
Namespace Changes for RuboCop 0.70

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -318,9 +318,6 @@ Style/Sample:
 Style/StabbyLambdaParentheses:
   Enabled: true
 
-Style/Strip:
-  Enabled: true
-
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,6 @@
-require: rubocop/cop/github
-require: rubocop-performance
+require: 
+  - rubocop/cop/github
+  - rubocop-performance
 
 AllCops:
   DisabledByDefault: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -115,6 +115,9 @@ Lint/EndInMethod:
 Lint/EnsureReturn:
   Enabled: true
 
+Lint/FlipFlop:
+  Enabled: true
+
 Lint/FloatOutOfRange:
   Enabled: true
 
@@ -226,9 +229,6 @@ Performance/EndWith:
 Performance/FlatMap:
   Enabled: true
 
-Style/Strip:
-  Enabled: true
-
 Performance/RangeInclude:
   Enabled: false
 
@@ -239,13 +239,7 @@ Performance/RedundantMerge:
   Enabled: true
   MaxKeyValuePairs: 1
 
-Style/RedundantSortBy:
-  Enabled: true
-
 Performance/ReverseEach:
-  Enabled: true
-
-Style/Sample:
   Enabled: true
 
 Performance/Size:
@@ -284,9 +278,6 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
-Lint/FlipFlop:
-  Enabled: true
-
 Style/For:
   Enabled: true
 
@@ -318,9 +309,18 @@ Style/Not:
 Style/OneLineConditional:
   Enabled: true
 
+Style/RedundantSortBy:
+  Enabled: true
+
+Style/Sample:
+  Enabled: true
+
 Style/StabbyLambdaParentheses:
   Enabled: true
 
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
+
+Style/Strip:
+  Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -226,7 +226,7 @@ Performance/EndWith:
 Performance/FlatMap:
   Enabled: true
 
-Style/LstripRstrip:
+Style/Strip:
   Enabled: true
 
 Performance/RangeInclude:

--- a/config/default.yml
+++ b/config/default.yml
@@ -226,7 +226,7 @@ Performance/EndWith:
 Performance/FlatMap:
   Enabled: true
 
-Performance/LstripRstrip:
+Style/LstripRstrip:
   Enabled: true
 
 Performance/RangeInclude:
@@ -239,13 +239,13 @@ Performance/RedundantMerge:
   Enabled: true
   MaxKeyValuePairs: 1
 
-Performance/RedundantSortBy:
+Style/RedundantSortBy:
   Enabled: true
 
 Performance/ReverseEach:
   Enabled: true
 
-Performance/Sample:
+Style/Sample:
   Enabled: true
 
 Performance/Size:
@@ -284,7 +284,7 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: true
 
 Style/For:

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 require: rubocop/cop/github
+require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.68"
+  s.add_dependency "rubocop", "~> 0.69"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
   s.add_dependency "rubocop", "~> 0.70"
+  s.add_dependency "rubocop-performance", "~> 1.3.0"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.69"
+  s.add_dependency "rubocop", "~> 0.70"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.59"
+  s.add_dependency "rubocop", "~> 0.67"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.67"
+  s.add_dependency "rubocop", "~> 0.68"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.10"
   s.add_development_dependency "rake", "~> 12.0"
 
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.3.6"
 
   s.email = "engineering@github.com"
   s.authors = "GitHub"


### PR DESCRIPTION
Drops support for Ruby < 2.3