### PR TITLE
Components allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ inherit_gem:
     - config/rails.yml
 ```
 
+## Testing
+
+`bundle install`
+`bundle exec rake test`
+
 ## The Cops
 
 All cops are located under [`lib/rubocop/cop/github`](lib/rubocop/cop/github), and contain examples/documentation.

--- a/config/default.yml
+++ b/config/default.yml
@@ -226,9 +226,6 @@ Performance/EndWith:
 Performance/FlatMap:
   Enabled: true
 
-Performance/LstripRstrip:
-  Enabled: true
-
 Performance/RangeInclude:
   Enabled: false
 
@@ -319,6 +316,9 @@ Style/OneLineConditional:
   Enabled: true
 
 Style/StabbyLambdaParentheses:
+  Enabled: true
+
+Style/Strip:
   Enabled: true
 
 Style/StringLiterals:

--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -20,6 +20,10 @@ module RuboCop
           (send nil? :render ({str sym} $_) $...)
         PATTERN
 
+        def_node_matcher :render_const?, <<-PATTERN
+          (send nil? :render (const nil? ...))
+        PATTERN
+
         def_node_matcher :render_with_options?, <<-PATTERN
           (send nil? :render (hash $...))
         PATTERN
@@ -63,7 +67,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node)
+          if render_literal?(node) || render_const?(node)
           elsif option_pairs = render_with_options?(node)
             option_pairs = option_pairs.reject { |pair| options_key?(pair) }
 

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -9,6 +9,18 @@ class TestRailsControllerRenderLiteral < CopTest
     RuboCop::Cop::GitHub::RailsControllerRenderLiteral
   end
 
+  def test_render_string_literal_class_name_no_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render MyClass
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_render_string_literal_action_name_no_offense
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base


### PR DESCRIPTION
This PR updates RailsControllerRenderLiteral to allow `render Component` syntax.

cc @jhawthorn 