### PR TITLE
allow kwargs with render Const call

### DIFF
--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -21,7 +21,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :render_const?, <<-PATTERN
-          (send nil? :render (const nil? ...))
+          (send nil? :render (const nil? ...) $...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -13,7 +13,7 @@ class TestRailsControllerRenderLiteral < CopTest
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base
         def index
-          render MyClass
+          render MyClass, title: "foo", bar: "baz"
         end
       end
     RUBY


### PR DESCRIPTION
As a followup to https://github.com/github/rubocop-github/pull/40, we need to allow kwargs when calling `render Const`.

cc @jhawthorn 