### PR TITLE
handle Module::Class syntax and block args

### DIFF
--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -21,7 +21,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :render_const?, <<-PATTERN
-          (send nil? :render (const nil? ...) $...)
+          (send nil? :render (const _ _) ...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -20,6 +20,10 @@ module RuboCop
           (send nil? :render ({str sym} $_) $...)
         PATTERN
 
+        def_node_matcher :render_const?, <<-PATTERN
+          (send nil? :render (const _ _) ...)
+        PATTERN
+
         def_node_matcher :render_with_options?, <<-PATTERN
           (send nil? :render (hash $...) ...)
         PATTERN
@@ -42,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node)
+          if render_literal?(node) || render_const?(node)
           elsif option_pairs = render_with_options?(node)
             if option_pairs.any? { |pair| ignore_key?(pair) }
               return

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -21,6 +21,32 @@ class TestRailsControllerRenderLiteral < CopTest
     assert_equal 0, cop.offenses.count
   end
 
+  def test_render_string_literal_module_class_name_no_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render Module::MyClass, title: "foo", bar: "baz"
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_string_literal_module_class_name_block_no_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render Module::MyClass, title: "foo", bar: "baz" do
+            "my block content"
+          end
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_render_string_literal_action_name_no_offense
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -46,6 +46,30 @@ class TestRailsViewRenderLiteral < CopTest
     assert_equal "render must be used with a string literal", cop.offenses[0].message
   end
 
+  def test_render_component_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render Module::MyClass, title: "foo", bar: "baz" %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_component_root_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render MyClass, title: "foo", bar: "baz" %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_component_block_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render Module::MyClass, title: "foo", bar: "baz" do %>Content<% end %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_render_layout_variable_literal_no_offense
     erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
       <%= render layout: magic_string do %>


### PR DESCRIPTION
On the heels of #40 and #41, we'll also need to allow the syntax `render Module::Class` and `render Module::Class { "content" }`.

We also needed to add these changes to the equivalent view linter.

cc @jhawthorn 