### PR TITLE
Disable InitialIndentation cop for view templates

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -116,3 +116,7 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Exclude:
     - 'app/views/**/*.erb'
+
+Layout/InitialIndentation:
+  Exclude:
+    - 'app/views/**/*.erb'


### PR DESCRIPTION
The InitialIndentation cop fails for some view templates in github/github on Rails 6 because of a change to ActionView's template parsing. In Rails 5.2, ActionView would add a preamble to the template's source and as a result we would never hit the InitialIndentation cop. The preamble was [removed in Rails 6](https://github.com/rails/rails/commit/ec5c946138f63dc975341d6521587adc74f6b441) so depending on the template it might seem like there's empty spaces at the beginning of the file.

Since the template is parsed as a single string, RuboCop can't really evaluate indentation anyways. Therefore, we can turn the InitialIndentation cop off.

## Notes

This is pulled from https://github.com/github/github/pull/116146.

/cc @github/ruby-architecture 