### PR TITLE
support rendering components as instances, not constants

### DIFF
--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module GitHub
       class RailsControllerRenderLiteral < Cop
-        MSG = "render must be used with a string literal"
+        MSG = "render must be used with a string literal or an instance of a Class"
 
         def_node_matcher :literal?, <<-PATTERN
           ({str sym true false nil?} ...)
@@ -20,8 +20,8 @@ module RuboCop
           (send nil? :render ({str sym} $_) $...)
         PATTERN
 
-        def_node_matcher :render_const?, <<-PATTERN
-          (send nil? :render (const _ _) ...)
+        def_node_matcher :render_inst?, <<-PATTERN
+          (send nil? :render (send _ :new ...) ...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN
@@ -67,7 +67,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node) || render_const?(node)
+          if render_literal?(node) || render_inst?(node)
           elsif option_pairs = render_with_options?(node)
             option_pairs = option_pairs.reject { |pair| options_key?(pair) }
 

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module GitHub
       class RailsViewRenderLiteral < Cop
-        MSG = "render must be used with a string literal"
+        MSG = "render must be used with a string literal or an instance of a Class"
 
         def_node_matcher :literal?, <<-PATTERN
           ({str sym true false nil?} ...)
@@ -20,8 +20,8 @@ module RuboCop
           (send nil? :render ({str sym} $_) $...)
         PATTERN
 
-        def_node_matcher :render_const?, <<-PATTERN
-          (send nil? :render (const _ _) ...)
+        def_node_matcher :render_inst?, <<-PATTERN
+          (send nil? :render (send _ :new ...) ...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN
@@ -46,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node) || render_const?(node)
+          if render_literal?(node) || render_inst?(node)
           elsif option_pairs = render_with_options?(node)
             if option_pairs.any? { |pair| ignore_key?(pair) }
               return

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -13,7 +13,7 @@ class TestRailsControllerRenderLiteral < CopTest
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base
         def index
-          render MyClass, title: "foo", bar: "baz"
+          render(MyClass.new(title: "foo", bar: "baz"))
         end
       end
     RUBY
@@ -25,7 +25,7 @@ class TestRailsControllerRenderLiteral < CopTest
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base
         def index
-          render Module::MyClass, title: "foo", bar: "baz"
+          render(Module::MyClass.new(title: "foo", bar: "baz"))
         end
       end
     RUBY
@@ -37,7 +37,7 @@ class TestRailsControllerRenderLiteral < CopTest
     investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
       class ProductsController < ActionController::Base
         def index
-          render Module::MyClass, title: "foo", bar: "baz" do
+          render(Module::MyClass.new(title: "foo", bar: "baz")) do
             "my block content"
           end
         end
@@ -250,7 +250,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_implicit_with_layout_offense
@@ -263,7 +263,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_implicit_with_status_offense
@@ -276,7 +276,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_variable_offense
@@ -289,7 +289,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_action_variable_offense
@@ -302,7 +302,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_template_variable_offense
@@ -315,7 +315,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_partial_variable_offense
@@ -328,7 +328,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_template_with_layout_variable_offense
@@ -341,7 +341,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_template_variable_with_layout_offense
@@ -354,6 +354,6 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 end

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -43,12 +43,12 @@ class TestRailsViewRenderLiteral < CopTest
     ERB
 
     assert_equal 2, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_component_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render Module::MyClass, title: "foo", bar: "baz" %>
+      <%= render Module::MyClass.new(, title: "foo", bar: "baz") %>
     ERB
 
     assert_equal 0, cop.offenses.count
@@ -56,7 +56,7 @@ class TestRailsViewRenderLiteral < CopTest
 
   def test_render_component_root_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render MyClass, title: "foo", bar: "baz" %>
+      <%= render MyClass.new(title: "foo", bar: "baz") %>
     ERB
 
     assert_equal 0, cop.offenses.count
@@ -64,7 +64,7 @@ class TestRailsViewRenderLiteral < CopTest
 
   def test_render_component_block_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render Module::MyClass, title: "foo", bar: "baz" do %>Content<% end %>
+      <%= render Module::MyClass.new(title: "foo", bar: "baz") do %>Content<% end %>
     ERB
 
     assert_equal 0, cop.offenses.count
@@ -78,7 +78,7 @@ class TestRailsViewRenderLiteral < CopTest
     ERB
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal", cop.offenses[0].message
+    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
 
   def test_render_inline_no_offense


### PR DESCRIPTION
In support of https://github.com/github/github/pull/117445, this PR changes the render format linter to work with passing in instances instead of class names.

cc @github/actionview-component-reviewers 