### PR TITLE
Revert "Namespace Changes for RuboCop 0.70"

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,4 @@
-require: 
-  - rubocop/cop/github
-  - rubocop-performance
+require: rubocop/cop/github
 
 AllCops:
   DisabledByDefault: true
@@ -115,9 +113,6 @@ Lint/EndInMethod:
   Enabled: true
 
 Lint/EnsureReturn:
-  Enabled: true
-
-Lint/FlipFlop:
   Enabled: true
 
 Lint/FloatOutOfRange:
@@ -241,7 +236,13 @@ Performance/RedundantMerge:
   Enabled: true
   MaxKeyValuePairs: 1
 
+Performance/RedundantSortBy:
+  Enabled: true
+
 Performance/ReverseEach:
+  Enabled: true
+
+Performance/Sample:
   Enabled: true
 
 Performance/Size:
@@ -280,6 +281,9 @@ Style/DefWithParentheses:
 Style/EndBlock:
   Enabled: true
 
+Style/FlipFlop:
+  Enabled: true
+
 Style/For:
   Enabled: true
 
@@ -311,18 +315,12 @@ Style/Not:
 Style/OneLineConditional:
   Enabled: true
 
-Style/RedundantSortBy:
-  Enabled: true
-
-Style/Sample:
-  Enabled: true
-
 Style/StabbyLambdaParentheses:
+  Enabled: true
+
+Style/Strip:
   Enabled: true
 
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
-
-Style/Strip:
-  Enabled: true

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,14 +10,13 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "~> 0.70"
-  s.add_dependency "rubocop-performance", "~> 1.3.0"
+  s.add_dependency "rubocop", "~> 0.59"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"
   s.add_development_dependency "rake", "~> 12.0"
 
-  s.required_ruby_version = ">= 2.3.6"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.email = "engineering@github.com"
   s.authors = "GitHub"


### PR DESCRIPTION
This PR made changes that were incompatible with our internal project dependencies. As the changes are minor, we are going to revert this for now.