### PR TITLE
ActiveSupport concerning supports access modifiers

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -120,3 +120,7 @@ Layout/TrailingWhitespace:
 Layout/InitialIndentation:
   Exclude:
     - 'app/views/**/*.erb'
+
+Lint/UselessAccessModifier:
+  ContextCreatingMethods:
+    - concerning


### PR DESCRIPTION
This change is necessary because access modifiers within `concerning` blocks are not useless.

[ActiveSupport::Module::Concerning](https://api.rubyonrails.org/classes/Module/Concerning.html)'s block creates a context in which access modifiers are respected.

see https://github.com/rubocop-hq/rubocop/issues/3422
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UselessAccessModifier