### PR TITLE
Bump rubocop dependency to 0.78.0

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -31,6 +31,9 @@ Layout/EndOfLine:
 Layout/InitialIndentation:
   Enabled: true
 
+Layout/LineLength:
+  Enabled: false
+
 Layout/SpaceAfterColon:
   Enabled: true
 
@@ -183,9 +186,6 @@ Metrics/ClassLength:
   Enabled: false
 
 Metrics/CyclomaticComplexity:
-  Enabled: false
-
-Metrics/LineLength:
   Enabled: false
 
 Metrics/MethodLength:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.77.0"
+  s.add_dependency "rubocop", "<=0.78.0"
   s.add_dependency "rubocop-performance", "~> 1.0"
   s.add_dependency "rubocop-rails", "~> 2.0"
 


### PR DESCRIPTION
Builds on https://github.com/github/rubocop-github/pull/59

~This is a breaking change.~

To get this to pass CI, I have done the following:

* ~deleted performance cops~
* renamed a Metrics/LineLength to Layout/LineLength

~The performance cops appear to have been extracted into a separate gem,
https://github.com/rubocop-hq/rubocop-performance and as of 0.78.0
referencing them without including the rubocop-performance gem as a
dependency blows up.~

Update: I updated the gemspec to include the rubocop-performance and rubocop-rails gems in https://github.com/github/rubocop-github/pull/63