### PR TITLE
Bump rubocop dependency to 0.81.0

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -113,9 +113,6 @@ Lint/EmptyEnsure:
 Lint/EmptyInterpolation:
   Enabled: true
 
-Lint/EndInMethod:
-  Enabled: true
-
 Lint/EnsureReturn:
   Enabled: true
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.78.0"
+  s.add_dependency "rubocop", "<=0.81.0"
   s.add_dependency "rubocop-performance", "~> 1.0"
   s.add_dependency "rubocop-rails", "~> 2.0"
 


### PR DESCRIPTION
This builds on https://github.com/github/rubocop-github/pull/60

This is a breaking change. To get this to pass CI
I had to delete the 'Lint/EndInMethod' cop, which has
been renamed to 'Style/EndBlock'. Since we already had
Style/EndBlock, I deleted rather than renaming the old
cop.