### PR TITLE
Bump rubocop to 0.82.0

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -28,6 +28,11 @@ Layout/EndAlignment:
 Layout/EndOfLine:
   Enabled: true
 
+Layout/IndentationStyle:
+  Enabled: true
+  EnforcedStyle: spaces
+  IndentationWidth: 2
+
 Layout/InitialIndentation:
   Enabled: true
 
@@ -75,9 +80,6 @@ Layout/SpaceInsideRangeLiteral:
   Enabled: true
 
 Layout/SpaceInsideReferenceBrackets:
-  Enabled: true
-
-Layout/Tab:
   Enabled: true
 
 Layout/TrailingEmptyLines:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.81.0"
+  s.add_dependency "rubocop", "<=0.82.0"
   s.add_dependency "rubocop-performance", "~> 1.0"
   s.add_dependency "rubocop-rails", "~> 2.0"
 


### PR DESCRIPTION

This is a breaking change.

In order to pass CI, I had to rename the Layout/Tab cop
to Layout/IndentationStyle.