### PR TITLE
Add performance and rails rubocop gems explicitly

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -1,4 +1,6 @@
-require: rubocop/cop/github
+require:
+  - rubocop/cop/github
+  - rubocop-performance
 
 # These cops are compatible across supported versions of rubocop
 

--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -77,7 +77,7 @@ Layout/SpaceInsideReferenceBrackets:
 Layout/Tab:
   Enabled: true
 
-Layout/TrailingEmptyLines:
+Layout/TrailingBlankLines:
   Enabled: true
 
 Layout/TrailingWhitespace:
@@ -95,7 +95,7 @@ Lint/DeprecatedClassMethods:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicateHashKey:
+Lint/DuplicatedKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -146,16 +146,16 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Enabled: true
 
-Lint/RedundantStringCoercion:
+Lint/StringConversionInInterpolation:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
-Lint/RedundantCopDisableDirective:
+Lint/UnneededCopDisableDirective:
   Enabled: true
 
-Lint/RedundantSplatExpansion:
+Lint/UnneededSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:

--- a/config/_rails_shared.yml
+++ b/config/_rails_shared.yml
@@ -103,7 +103,7 @@ Style/StringLiterals:
   Exclude:
     - 'app/views/**/*.erb'
 
-Layout/TrailingEmptyLines:
+Layout/TrailingBlankLines:
   Exclude:
     - 'app/views/**/*.erb'
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -11,11 +11,8 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
   s.add_dependency "rubocop", "<=0.75.0"
-  # TODO: If you use this gem in "edge" mode, it requires both
-  # rubocop-performance and rubocop-rails but it's not currently possible to
-  # add these to the gemspec because both of them require a ver recent version
-  # of rubocop which would break any clients that accidentally `bundle update`.
-  # This should become much simpler once this gem reaches v1
+  s.add_dependency "rubocop-performance", "~> 1.0"
+  s.add_dependency "rubocop-rails", "~> 2.0"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
These were implied before, but couldn't be added as dependencies due to version hell.

Note: this is a replacement for #63 which I forgot to change the base branch of, and merged into an already merged PR).