### PR TITLE
Bump rubocop to v0.76.0

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -152,10 +152,10 @@ Lint/StringConversionInInterpolation:
 Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.75.0"
+  s.add_dependency "rubocop", "<=0.76.0"
   s.add_dependency "rubocop-performance", "~> 1.0"
   s.add_dependency "rubocop-rails", "~> 2.0"
 


### PR DESCRIPTION
This was a breaking change, and I had to rename a couple of cops
to get the build passing.