### PR TITLE
Bump rubocop to 0.77.0

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -77,7 +77,7 @@ Layout/SpaceInsideReferenceBrackets:
 Layout/Tab:
   Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:
@@ -95,7 +95,7 @@ Lint/DeprecatedClassMethods:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -146,7 +146,7 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:

--- a/config/_rails_shared.yml
+++ b/config/_rails_shared.yml
@@ -103,7 +103,7 @@ Style/StringLiterals:
   Exclude:
     - 'app/views/**/*.erb'
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Exclude:
     - 'app/views/**/*.erb'
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.76.0"
+  s.add_dependency "rubocop", "<=0.77.0"
   s.add_dependency "rubocop-performance", "~> 1.0"
   s.add_dependency "rubocop-rails", "~> 2.0"
 


### PR DESCRIPTION
This version of rubocop has a breaking change.

I've updated cops that got renamed.