### PR TITLE
Support latest ViewComponent syntax

### DIFF
--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -24,6 +24,10 @@ module RuboCop
           (send nil? :render (send _ :new ...) ...)
         PATTERN
 
+        def_node_matcher :render_collection?, <<-PATTERN
+          (send nil? :render (send _ :collection ...) ...)
+        PATTERN
+
         def_node_matcher :render_with_options?, <<-PATTERN
           (send nil? :render (hash $...) ...)
         PATTERN
@@ -46,7 +50,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node) || render_inst?(node)
+          if render_literal?(node) || render_inst?(node) || render_collection?(node)
           elsif option_pairs = render_with_options?(node)
             if option_pairs.any? { |pair| ignore_key?(pair) }
               return

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -24,10 +24,6 @@ module RuboCop
           (send nil? :render (send _ :new ...) ...)
         PATTERN
 
-        def_node_matcher :render_const?, <<-PATTERN
-          (send nil? :render (const _ _) ...)
-        PATTERN
-
         def_node_matcher :render_with_options?, <<-PATTERN
           (send nil? :render (hash $...) ...)
         PATTERN
@@ -50,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node) || render_inst?(node) || render_const?(node)
+          if render_literal?(node) || render_inst?(node)
           elsif option_pairs = render_with_options?(node)
             if option_pairs.any? { |pair| ignore_key?(pair) }
               return

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -25,7 +25,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :render_collection?, <<-PATTERN
-          (send nil? :render (send _ :collection ...) ...)
+          (send nil? :render (send _ :with_collection ...) ...)
         PATTERN
 
         def_node_matcher :render_with_options?, <<-PATTERN

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -72,7 +72,7 @@ class TestRailsViewRenderLiteral < CopTest
 
   def test_render_component_collection_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render MyClass.collection(title: "foo", bar: "baz") %>
+      <%= render MyClass.with_collection(title: "foo", bar: "baz") %>
     ERB
 
     assert_equal 0, cop.offenses.count
@@ -80,7 +80,7 @@ class TestRailsViewRenderLiteral < CopTest
 
   def test_render_component_module_collection_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render Foo::MyClass.collection(title: "foo", bar: "baz") %>
+      <%= render Foo::MyClass.with_collection(title: "foo", bar: "baz") %>
     ERB
 
     assert_equal 0, cop.offenses.count

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -70,6 +70,22 @@ class TestRailsViewRenderLiteral < CopTest
     assert_equal 0, cop.offenses.count
   end
 
+  def test_render_component_collection_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render MyClass.collection(title: "foo", bar: "baz") %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_component_module_collection_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render Foo::MyClass.collection(title: "foo", bar: "baz") %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_render_layout_variable_literal_no_offense
     erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
       <%= render layout: magic_string do %>

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -54,22 +54,6 @@ class TestRailsViewRenderLiteral < CopTest
     assert_equal 0, cop.offenses.count
   end
 
-  def test_render_component_class_name_no_offense
-    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render Module::MyClass, title: "foo", bar: "baz" %>
-    ERB
-
-    assert_equal 0, cop.offenses.count
-  end
-
-  def test_render_component_class_no_offense
-    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render MyClass, title: "foo", bar: "baz" %>
-    ERB
-
-    assert_equal 0, cop.offenses.count
-  end
-
   def test_render_component_instance_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
       <%= render MyClass.new(title: "foo", bar: "baz") %>
@@ -81,14 +65,6 @@ class TestRailsViewRenderLiteral < CopTest
   def test_render_component_instance_block_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
       <%= render Module::MyClass.new(title: "foo", bar: "baz") do %>Content<% end %>
-    ERB
-
-    assert_equal 0, cop.offenses.count
-  end
-
-  def test_render_component_class_block_no_offense
-    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
-      <%= render Module::MyClass, title: "foo", bar: "baz" do %>Content<% end %>
     ERB
 
     assert_equal 0, cop.offenses.count


### PR DESCRIPTION
This PR accommodates two syntax changes in ViewComponent:

1) No longer supporting rendering the component constant: `render(MyComponent)`
2) Allowing components to render collections: `render(MyComponent.with_collection)`.

cc @kytrinyx @mxie @github/view-component-reviewers 