### PR TITLE
Rubocop 8.9

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -163,7 +163,7 @@ Lint/RedundantSplatExpansion:
 Lint/UnreachableCode:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessSetterCall:

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rubocop-github"
-  s.version = "0.16.0"
+  s.version = "0.16.1"
   s.summary = "RuboCop GitHub"
   s.description = "Code style checking for GitHub Ruby repositories "
   s.homepage = "https://github.com/github/rubocop-github"
@@ -10,9 +10,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<= 0.88.0"
+  s.add_dependency "rubocop", "<= 0.89.0"
   s.add_dependency "rubocop-performance", "<= 1.7.1"
-  s.add_dependency "rubocop-rails", "<= 2.7.0"
+  s.add_dependency "rubocop-rails", "<= 2.7.1"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<=0.82.0"
-  s.add_dependency "rubocop-performance", "~> 1.0"
-  s.add_dependency "rubocop-rails", "~> 2.0"
+  s.add_dependency "rubocop", "<= 0.88.0"
+  s.add_dependency "rubocop-performance", "<= 1.7.1"
+  s.add_dependency "rubocop-rails", "<= 2.7.0"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
We ended up needing a few more changes not in https://github.com/github/rubocop-github/pull/72 to get fully up to date with rubocop.