### PR TITLE
STYLEGUIDE: raise maximum characters.

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -2,7 +2,7 @@
 
 * Use soft-tabs with a two space indent.
 
-* Keep each line of code to a readable length. Unless you have a reason to, keep lines to fewer than 100 characters.
+* Keep each line of code to a readable length. Unless you have a reason to, keep lines to a maximum of 118 characters. Why 118? That's the width at which the pull request diff UI needs horizontal scrolling (making pull requests harder to review).
 
 * Never leave trailing whitespace.
 


### PR DESCRIPTION
This rule is very loosely conformed to and 100 seems fairly arbitrary. Instead, let's loosen it slightly and provide a justification for that loosening.

CC @cheshire137 who pointed this out to me in https://github.com/github/github/pull/160489#discussion_r513778065.

As an unrelated comment: it would be lovely if we could (one day) punt rules like this to RuboCop itself and have it populate all existing TODOs/exceptions. This is exactly the type of rule best done by machines rather than humans 🤖 👩🏻‍🎨 