### PR TITLE
Enforce local keys being literals

### DIFF
--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -6,7 +6,7 @@ module RuboCop
   module Cop
     module GitHub
       class RailsViewRenderLiteral < Cop
-        MSG = "render must be used with a string literal or an instance of a Class"
+        MSG = "render must be used with a literal template and use literals for locals keys"
 
         def_node_matcher :literal?, <<-PATTERN
           ({str sym true false nil?} ...)
@@ -20,11 +20,11 @@ module RuboCop
           (send nil? {:render :render_to_string} ({str sym} $_) $...)
         PATTERN
 
-        def_node_matcher :render_inst?, <<-PATTERN
+        def_node_matcher :render_view_component?, <<-PATTERN
           (send nil? {:render :render_to_string} (send _ :new ...) ...)
         PATTERN
 
-        def_node_matcher :render_collection?, <<-PATTERN
+        def_node_matcher :render_view_component_collection?, <<-PATTERN
           (send nil? {:render :render_to_string} (send _ :with_collection ...) ...)
         PATTERN
 
@@ -38,6 +38,12 @@ module RuboCop
           }) $_)
         PATTERN
 
+        def_node_matcher :locals_key?, <<-PATTERN
+          (pair (sym {
+            :locals
+          }) $_)
+        PATTERN
+
         def_node_matcher :partial_key?, <<-PATTERN
           (pair (sym {
             :file
@@ -47,10 +53,17 @@ module RuboCop
           }) $_)
         PATTERN
 
+        def hash_with_literal_keys?(hash)
+          hash.pairs.all? { |pair| literal?(pair.key) }
+        end
+
         def on_send(node)
           return unless render?(node)
 
-          if render_literal?(node) || render_inst?(node) || render_collection?(node)
+          # Ignore "component"-style renders
+          return if render_view_component?(node) || render_view_component_collection?(node)
+
+          if render_literal?(node)
           elsif option_pairs = render_with_options?(node)
             if option_pairs.any? { |pair| ignore_key?(pair) }
               return
@@ -59,12 +72,31 @@ module RuboCop
             if partial_node = option_pairs.map { |pair| partial_key?(pair) }.compact.first
               if !literal?(partial_node)
                 add_offense(node, location: :expression)
+                return
+              end
+            else
+              add_offense(node, location: :expression)
+              return
+            end
+          else
+            add_offense(node, location: :expression)
+            return
+          end
+
+          if render_literal?(node) && node.arguments.count > 1
+            locals = node.arguments[1]
+          elsif options_pairs = render_with_options?(node)
+            locals = option_pairs.map { |pair| locals_key?(pair) }.compact.first
+          end
+
+          if locals
+            if locals.hash_type?
+              if !hash_with_literal_keys?(locals)
+                add_offense(node, location: :expression)
               end
             else
               add_offense(node, location: :expression)
             end
-          else
-            add_offense(node, location: :expression)
           end
         end
       end

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -1,36 +1,15 @@
 # frozen_string_literal: true
 
 require "rubocop"
+require "rubocop/cop/github/render_literal_helpers"
 
 module RuboCop
   module Cop
     module GitHub
       class RailsViewRenderLiteral < Cop
+        include RenderLiteralHelpers
+
         MSG = "render must be used with a literal template and use literals for locals keys"
-
-        def_node_matcher :literal?, <<-PATTERN
-          ({str sym true false nil?} ...)
-        PATTERN
-
-        def_node_matcher :render?, <<-PATTERN
-          (send nil? {:render :render_to_string} $...)
-        PATTERN
-
-        def_node_matcher :render_literal?, <<-PATTERN
-          (send nil? {:render :render_to_string} ({str sym} $_) $...)
-        PATTERN
-
-        def_node_matcher :render_view_component?, <<-PATTERN
-          (send nil? {:render :render_to_string} (send _ :new ...) ...)
-        PATTERN
-
-        def_node_matcher :render_view_component_collection?, <<-PATTERN
-          (send nil? {:render :render_to_string} (send _ :with_collection ...) ...)
-        PATTERN
-
-        def_node_matcher :render_with_options?, <<-PATTERN
-          (send nil? {:render :render_to_string} (hash $...) ...)
-        PATTERN
 
         def_node_matcher :ignore_key?, <<-PATTERN
           (pair (sym {
@@ -61,7 +40,7 @@ module RuboCop
           return unless render?(node)
 
           # Ignore "component"-style renders
-          return if render_view_component?(node) || render_view_component_collection?(node)
+          return if render_view_component?(node)
 
           if render_literal?(node)
           elsif option_pairs = render_with_options?(node)

--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -17,12 +17,6 @@ module RuboCop
           }) $_)
         PATTERN
 
-        def_node_matcher :locals_key?, <<-PATTERN
-          (pair (sym {
-            :locals
-          }) $_)
-        PATTERN
-
         def_node_matcher :partial_key?, <<-PATTERN
           (pair (sym {
             :file
@@ -31,10 +25,6 @@ module RuboCop
             :partial
           }) $_)
         PATTERN
-
-        def hash_with_literal_keys?(hash)
-          hash.pairs.all? { |pair| literal?(pair.key) }
-        end
 
         def on_send(node)
           return unless render?(node)

--- a/lib/rubocop/cop/github/render_literal_helpers.rb
+++ b/lib/rubocop/cop/github/render_literal_helpers.rb
@@ -36,6 +36,14 @@ module RuboCop
           (send nil? {:render :render_to_string} (send _ :with_collection ...) ...)
         PATTERN
 
+        def_node_matcher :locals_key?, <<-PATTERN
+          (pair (sym :locals) $_)
+        PATTERN
+
+        def hash_with_literal_keys?(hash)
+          hash.pairs.all? { |pair| literal?(pair.key) }
+        end
+
         def render_view_component?(node)
           render_view_component_instance?(node) ||
             render_view_component_collection?(node)

--- a/lib/rubocop/cop/github/render_literal_helpers.rb
+++ b/lib/rubocop/cop/github/render_literal_helpers.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+#
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module GitHub
+      module RenderLiteralHelpers
+        extend NodePattern::Macros
+
+        def_node_matcher :literal?, <<-PATTERN
+          ({str sym true false nil?} ...)
+        PATTERN
+
+        def_node_matcher :render?, <<-PATTERN
+          (send nil? {:render :render_to_string} ...)
+        PATTERN
+
+        def_node_matcher :render_literal?, <<-PATTERN
+          (send nil? {:render :render_to_string} ({str sym} $_) $...)
+        PATTERN
+
+        def_node_matcher :render_inst?, <<-PATTERN
+          (send nil? {:render :render_to_string} (send _ :new ...) ...)
+        PATTERN
+
+        def_node_matcher :render_with_options?, <<-PATTERN
+          (send nil? {:render :render_to_string} (hash $...) ...)
+        PATTERN
+
+        def_node_matcher :render_view_component_instance?, <<-PATTERN
+          (send nil? {:render :render_to_string} (send _ :new ...) ...)
+        PATTERN
+
+        def_node_matcher :render_view_component_collection?, <<-PATTERN
+          (send nil? {:render :render_to_string} (send _ :with_collection ...) ...)
+        PATTERN
+
+        def render_view_component?(node)
+          render_view_component_instance?(node) ||
+            render_view_component_collection?(node)
+        end
+      end
+    end
+  end
+end

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -393,4 +393,65 @@ class TestRailsControllerRenderLiteral < CopTest
     assert_equal 1, cop.offenses.count
     assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
   end
+
+  def test_render_shorthand_static_locals_no_offsense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render "products/index", locals: { product: product }
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_partial_static_locals_no_offsense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render partial: "products/index", locals: { product: product }
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_literal_dynamic_options_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render "products/product", options
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_render_literal_dynamic_locals_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render "products/product", locals: locals
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
+
+
+  def test_render_literal_dynamic_local_key_offense
+    investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render "products/product", locals: { product_key => product }
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
 end

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -43,7 +43,7 @@ class TestRailsViewRenderLiteral < CopTest
     ERB
 
     assert_equal 2, cop.offenses.count
-    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
+    assert_equal "render must be used with a literal template and use literals for locals keys", cop.offenses[0].message
   end
 
   def test_render_component_no_offense
@@ -94,7 +94,7 @@ class TestRailsViewRenderLiteral < CopTest
     ERB
 
     assert_equal 1, cop.offenses.count
-    assert_equal "render must be used with a string literal or an instance of a Class", cop.offenses[0].message
+    assert_equal "render must be used with a literal template and use literals for locals keys", cop.offenses[0].message
   end
 
   def test_render_inline_no_offense
@@ -111,5 +111,53 @@ class TestRailsViewRenderLiteral < CopTest
     ERB
 
     assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_literal_static_locals_no_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render "products/product", product: product %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_literal_dynamic_locals_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render "products/product", locals %>
+    ERB
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_render_literal_dynamic_local_key_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render "products/product", { product_key => product } %>
+    ERB
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_render_options_static_locals_no_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render partial: "products/product", locals: { product: product } %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_render_options_dynamic_locals_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render partial: "products/product", locals: locals %>
+    ERB
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_render_options_dynamic_local_key_offense
+    erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render partial: "products/product", locals: { product_key => product } %>
+    ERB
+
+    assert_equal 1, cop.offenses.count
   end
 end


### PR DESCRIPTION
Previously we were enforcing that the template name of render calls was a static literal, but we weren't enforcing that locals was the same way.

This is necessary for `actionview_precompiler` to detect render calls and is a good practice anyways.

I believe it was just an oversight that this wasn't done previously.