### PR TITLE
Add check for insecure hash algorithms

### DIFF
--- a/config/_default_shared.yml
+++ b/config/_default_shared.yml
@@ -10,6 +10,9 @@ Bundler/DuplicatedGem:
 Bundler/OrderedGems:
   Enabled: true
 
+GitHub/InsecureHashAlgorithm:
+  Enabled: true
+
 Layout/BlockAlignment:
   Enabled: true
 

--- a/lib/rubocop/cop/github.rb
+++ b/lib/rubocop/cop/github.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rubocop/cop/github/insecure_hash_algorithm"
 require "rubocop/cop/github/rails_application_record"
 require "rubocop/cop/github/rails_controller_render_action_symbol"
 require "rubocop/cop/github/rails_controller_render_literal"

--- a/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/github/insecure_hash_algorithm.rb
@@ -27,7 +27,7 @@ module RuboCop
         def_node_matcher :insecure_digest?, <<-PATTERN
           (send
             (const _ {:Digest :HMAC})
-            _
+            #not_just_encoding?
             #insecure_algorithm?
             ...)
         PATTERN
@@ -38,12 +38,21 @@ module RuboCop
         PATTERN
 
         def insecure_algorithm?(val)
+          return false if val == :Digest # Don't match "Digest::Digest".
           case str_val(val).downcase
-          when "md5", "sha1"
-            true
-          else
+          when "ripemd160", "rmd160", "sha224", "sha256", "sha384", "sha512"
             false
+          else
+            true
           end
+        end
+
+        def not_just_encoding?(val)
+          !just_encoding?(val)
+        end
+
+        def just_encoding?(val)
+          val == :hexencode || val == :bubblebabble
         end
 
         def str_val(val)

--- a/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/github/insecure_hash_algorithm.rb
@@ -6,10 +6,15 @@ module RuboCop
   module Cop
     module GitHub
       class InsecureHashAlgorithm < Cop
-        MESSAGE = "This hash algorithm is old and insecure and should not be used. Please use SHA256 instead."
+        MSG = "This hash algorithm is old and insecure, use SHA-256 instead"
 
-        def_node_matcher :insecure_const?, "(const (const _ :Digest) #insecure_algorithm?)"
-        def_node_matcher :insecure_call?, "(send (const _ {:Digest :HMAC}) _ (str #insecure_algorithm?) ...)"
+        def_node_matcher :insecure_const?, <<-PATTERN
+          (const (const _ :Digest) #insecure_algorithm?)
+        PATTERN
+
+        def_node_matcher :insecure_call?, <<-PATTERN
+          (send (const _ {:Digest :HMAC}) _ (str #insecure_algorithm?) ...)
+        PATTERN
 
         def insecure_algorithm?(val)
           case val.to_s.downcase
@@ -22,13 +27,13 @@ module RuboCop
 
         def on_const(const_node)
           if insecure_const?(const_node)
-            add_offense(const_node, message: MESSAGE)
+            add_offense(const_node, message: MSG)
           end
         end
 
         def on_send(send_node)
           if insecure_call?(send_node)
-            add_offense(send_node, message: MESSAGE)
+            add_offense(send_node, message: MSG)
           end
         end
       end

--- a/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/github/insecure_hash_algorithm.rb
@@ -59,9 +59,6 @@ module RuboCop
         #  https://ruby-doc.org/stdlib-2.7.0/libdoc/digest/rdoc/Digest.html
         #  https://ruby-doc.org/stdlib-2.7.0/libdoc/openssl/rdoc/OpenSSL/Digest.html
         DEFAULT_ALLOWED = %w[
-          RIPEMD160
-          RMD160
-          SHA224
           SHA256
           SHA384
           SHA512

--- a/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/github/insecure_hash_algorithm.rb
@@ -7,6 +7,8 @@ module RuboCop
     module GitHub
       class InsecureHashAlgorithm < Cop
         MSG = "This hash function is not allowed"
+        UUID_V3_MSG = "uuid_v3 uses MD5, which is not allowed"
+        UUID_V5_MSG = "uuid_v5 uses SHA1, which is not allowed"
 
         # Matches constants like these:
         #   Digest::MD5
@@ -45,6 +47,19 @@ module RuboCop
         # Matches calls like "OpenSSL::HMAC.new(secret, 'sha1')"
         def_node_matcher :openssl_hmac_new_insecure?, <<-PATTERN
           (send (const (const _ :OpenSSL) :HMAC) :new _ #insecure_algorithm?)
+        PATTERN
+
+        # Matches Rails's Digest::UUID.
+        def_node_matcher :digest_uuid?, <<-PATTERN
+          (const (const _ :Digest) :UUID)
+        PATTERN
+
+        def_node_matcher :uuid_v3?, <<-PATTERN
+          (send (const _ :UUID) :uuid_v3 ...)
+        PATTERN
+
+        def_node_matcher :uuid_v5?, <<-PATTERN
+          (send (const _ :UUID) :uuid_v5 ...)
         PATTERN
 
         def insecure_algorithm?(val)
@@ -93,13 +108,21 @@ module RuboCop
         end
 
         def on_const(const_node)
-          if insecure_const?(const_node)
+          if insecure_const?(const_node) && !digest_uuid?(const_node)
             add_offense(const_node, message: MSG)
           end
         end
 
         def on_send(send_node)
           case
+          when uuid_v3?(send_node)
+            unless allowed_hash_functions.include?("md5")
+              add_offense(send_node, message: UUID_V3_MSG)
+            end
+          when uuid_v5?(send_node)
+            unless allowed_hash_functions.include?("sha1")
+              add_offense(send_node, message: UUID_V5_MSG)
+            end
           when openssl_hmac_new?(send_node)
             if openssl_hmac_new_insecure?(send_node)
               add_offense(send_node, message: MSG)

--- a/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/github/insecure_hash_algorithm.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module GitHub
+      class InsecureHashAlgorithm < Cop
+        MESSAGE = "This hash algorithm is old and insecure and should not be used. Please use SHA256 instead."
+
+        def_node_matcher :insecure_const?, "(const (const _ :Digest) #insecure_algorithm?)"
+        def_node_matcher :insecure_call?, "(send (const _ {:Digest :HMAC}) _ (str #insecure_algorithm?) ...)"
+
+        def insecure_algorithm?(val)
+          case val.to_s.downcase
+          when "md5", "sha1"
+            true
+          else
+            false
+          end
+        end
+
+        def on_const(const_node)
+          if insecure_const?(const_node)
+            add_offense(const_node, message: MESSAGE)
+          end
+        end
+
+        def on_send(send_node)
+          if insecure_call?(send_node)
+            add_offense(send_node, message: MESSAGE)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -9,52 +9,232 @@ class TestInsecureHashAlgorithm < CopTest
     RuboCop::Cop::GitHub::InsecureHashAlgorithm
   end
 
-  def test_kitchen_sink
+  def test_alias_for_digest_md5
     investigate(cop, <<-RUBY)
       class Something
-        BAD_ALGO = Digest::MD5
-                   #^^^^^^^^^^^ #{message}
-        GOOD_ALGO = Digest::SHA256
-        OBAD_ALGO = OpenSSL::Digest::MD5
-                    #^^^^^^^^^^^^^^^^^^^^ #{message}
-        BAD_SHA1_ALGO = Digest::SHA1
-                        #^^^^^^^^^^^^ #{message}
-        OBAD_SHA1_ALGO = OpenSSL::Digest::SHA1
-                         #^^^^^^^^^^^^^^^^^^^^^ #{message}
+        HASH = Digest::MD5
+      end
+    RUBY
 
-        def kitchen_sink_hash(str)
-          BAD_ALGO.hexdigest(str) +
-            GOOD_ALGO.hexdigest(str) +
-            Digest::MD5.hexdigest(str) +
-            #^^^^^^^^^^^ #{message}
-            Digest::SHA1.hexdigest(str) +
-            #^^^^^^^^^^^^ #{message}
-            OpenSSL::Digest::MD5.hexdigest(str) +
-            #^^^^^^^^^^^^^^^^^^^^ #{message}
-            OpenSSL::Digest::SHA1.hexdigest(str)
-            #^^^^^^^^^^^^^^^^^^^^^ #{message}
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_alias_for_openssl_digest_md5
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = OpenSSL::Digest::MD5
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_alias_for_digest_sha1
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = Digest::SHA1
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_alias_for_openssl_digest_sha1
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = OpenSSL::Digest::SHA1
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_alias_for_digest_sha256
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = Digest::SHA256
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_alias_for_openssl_digest_sha256
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = OpenSSL::Digest::SHA256
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_hexdigest_on_random_class
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
+          HASH.hexdigest(str)
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_md5_hexdigest
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
+          Digest::MD5.hexdigest(str)
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_md5_hexdigest
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
+          OpenSSL::Digest::MD5.hexdigest(str)
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_md5_digest_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest.digest("MD5", str)
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha1_digest_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest.digest("SHA1", str)
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha1_hexdigest_by_name_mixed_case
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest.hexdigest("Sha1", str)
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha256_digest_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest.digest("SHA256", str)
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_openssl_md5_hmac_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::HMAC.hexdigest('md5', str)
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha1_hmac_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::HMAC.hexdigest('sha1', str)
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha256_hmac_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::HMAC.hexdigest('sha256', str)
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_openssl_md5_digest_instance_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest::Digest.new('md5')
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha1_digest_instance_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest::Digest.new('sha1')
-          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+  end
+
+  def test_openssl_sha256_digest_instance_by_name
+    investigate(cop, <<-RUBY)
+      class Something
+        def something(str)
           OpenSSL::Digest::Digest.new('sha256')
         end
       end
     RUBY
 
-    assert_equal 15, cop.offenses.count
-    assert_equal([cop_class::MESSAGE], cop.offenses.map(&:message).uniq)
+    assert_equal 0, cop.offenses.count
   end
 end

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -17,7 +17,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_alias_for_openssl_digest_md5
@@ -28,7 +28,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_alias_for_digest_sha1
@@ -39,7 +39,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_alias_for_openssl_digest_sha1
@@ -50,7 +50,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_alias_for_digest_sha256
@@ -95,7 +95,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_md5_hexdigest
@@ -108,7 +108,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_md5_digest_by_name
@@ -121,7 +121,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha1_digest_by_name
@@ -134,7 +134,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha1_hexdigest_by_name_mixed_case
@@ -147,7 +147,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha256_digest_by_name
@@ -172,7 +172,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha1_hmac_by_name
@@ -185,7 +185,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha256_hmac_by_name
@@ -210,7 +210,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha1_digest_instance_by_name
@@ -223,7 +223,7 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal cop_class::MESSAGE, cop.offenses.first.message
+    assert_equal cop_class::MSG, cop.offenses.first.message
   end
 
   def test_openssl_sha256_digest_instance_by_name

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -9,6 +9,11 @@ class TestInsecureHashAlgorithm < CopTest
     RuboCop::Cop::GitHub::InsecureHashAlgorithm
   end
 
+  def make_cop(config_hash)
+    config = RuboCop::Config.new({"GitHub/InsecureHashAlgorithm" => config_hash})
+    cop_class.new(config)
+  end
+
   def test_benign_apis
     investigate(cop, <<-RUBY)
       class Something
@@ -304,6 +309,26 @@ class TestInsecureHashAlgorithm < CopTest
       end
     RUBY
 
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_allow_sha512_only
+    cop = make_cop "Allowed" => %w[SHA512]
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = Digest::SHA256
+      end
+    RUBY
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_allow_lots_of_hashes
+    cop = make_cop "Allowed" => %w[SHA1 SHA256 SHA384 SHA512]
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = Digest::SHA1
+      end
+    RUBY
     assert_equal 0, cop.offenses.count
   end
 end

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -29,6 +29,37 @@ class TestInsecureHashAlgorithm < CopTest
     assert_equal 0, cop.offenses.count
   end
 
+  def test_openssl_hmac_new_sha256_indirect
+    investigate(cop, <<-RUBY)
+      class Something
+        HASH = OpenSSL::Digest::SHA256
+
+        attr :secret
+
+        def secret_hmac
+          OpenSSL::HMAC.new(self.secret, HASH)
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_openssl_hmac_new_sha1
+    investigate(cop, <<-RUBY)
+      class Something
+        attr :secret
+
+        def secret_hmac
+          OpenSSL::HMAC.new(self.secret, 'sha1')
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MSG, cop.offenses.first.message
+  end
+
   def test_digest_method_md5_str
     investigate(cop, <<-RUBY)
       class Something

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -9,6 +9,75 @@ class TestInsecureHashAlgorithm < CopTest
     RuboCop::Cop::GitHub::InsecureHashAlgorithm
   end
 
+  def test_benign_apis
+    investigate(cop, <<-RUBY)
+      class Something
+        def hexencode_the_string_md5
+          Digest.hexencode('anything')
+        end
+        def bubblebabble_the_string_md5
+          Digest.bubblebabble('anything')
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_digest_method_md5_str
+    investigate(cop, <<-RUBY)
+      class Something
+        def h
+          Digest('md5')
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MSG, cop.offenses.first.message
+  end
+
+  def test_digest_method_md5_symbol
+    investigate(cop, <<-RUBY)
+      class Something
+        def h
+          Digest(:MD5)
+        end
+      end
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal cop_class::MSG, cop.offenses.first.message
+  end
+
+  def test_digest_method_sha256_str
+    investigate(cop, <<-RUBY)
+      class Something
+        def h
+          Digest('sha256')
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_digest_method_sha256_symbol
+    investigate(cop, <<-RUBY)
+      class Something
+        def h
+          Digest('sha256')
+        end
+
+        def h
+          Digest(:SHA256)
+        end
+      end
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_alias_for_digest_md5
     investigate(cop, <<-RUBY)
       class Something

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -362,4 +362,16 @@ class TestInsecureHashAlgorithm < CopTest
     RUBY
     assert_equal 0, cop.offenses.count
   end
+
+  def test_allow_other_digest_types
+    cop = make_cop "Allowed" => %w[UUID]
+    investigate(cop, <<-RUBY)
+      class Something
+        def uuid
+          Digest::UUID.create
+        end
+      end
+    RUBY
+    assert_equal 0, cop.offenses.count
+  end
 end

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative "./cop_test"
+require "minitest/autorun"
+require "rubocop/cop/github/insecure_hash_algorithm"
+
+class TestInsecureHashAlgorithm < CopTest
+  def cop_class
+    RuboCop::Cop::GitHub::InsecureHashAlgorithm
+  end
+
+  def test_kitchen_sink
+    investigate(cop, <<-RUBY)
+      class Something
+        BAD_ALGO = Digest::MD5
+                   #^^^^^^^^^^^ #{message}
+        GOOD_ALGO = Digest::SHA256
+        OBAD_ALGO = OpenSSL::Digest::MD5
+                    #^^^^^^^^^^^^^^^^^^^^ #{message}
+        BAD_SHA1_ALGO = Digest::SHA1
+                        #^^^^^^^^^^^^ #{message}
+        OBAD_SHA1_ALGO = OpenSSL::Digest::SHA1
+                         #^^^^^^^^^^^^^^^^^^^^^ #{message}
+
+        def kitchen_sink_hash(str)
+          BAD_ALGO.hexdigest(str) +
+            GOOD_ALGO.hexdigest(str) +
+            Digest::MD5.hexdigest(str) +
+            #^^^^^^^^^^^ #{message}
+            Digest::SHA1.hexdigest(str) +
+            #^^^^^^^^^^^^ #{message}
+            OpenSSL::Digest::MD5.hexdigest(str) +
+            #^^^^^^^^^^^^^^^^^^^^ #{message}
+            OpenSSL::Digest::SHA1.hexdigest(str)
+            #^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest.digest("MD5", str)
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest.digest("SHA1", str)
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest.hexdigest("Sha1", str)
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest.digest("SHA256", str)
+          OpenSSL::HMAC.hexdigest('md5', str)
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::HMAC.hexdigest('sha1', str)
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::HMAC.hexdigest('sha256', str)
+          OpenSSL::Digest::Digest.new('md5')
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest::Digest.new('sha1')
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+          OpenSSL::Digest::Digest.new('sha256')
+        end
+      end
+    RUBY
+
+    assert_equal 15, cop.offenses.count
+    assert_equal([cop_class::MESSAGE], cop.offenses.map(&:message).uniq)
+  end
+end


### PR DESCRIPTION
MD5 and SHA1 are both subject to well-known attacks and are not recommended for use. This branch adds a cop that checks for these hash functions and recommends SHA256 in their place.

cc @dbussink @jhawthorn 