### PR TITLE
STYLEGUIDE.md: consistent use of parenthesis on Keyword Arguments

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -371,7 +371,7 @@ def remove_member(user, skip_membership_check: false)
 end
 
 # Elsewhere, now with more clarity:
-remove_member user, skip_membership_check: true
+remove_member(user, skip_membership_check: true)
 ```
 
 ## Naming


### PR DESCRIPTION
For maximum clarity, examples should differ only on the relevant parts. Because parenthesis were used in the `bad` example and aren’t relevant to the rule, adding them on the `good` example.