### PR TITLE
Bump rubocop & rubocop-performance version

### DIFF
--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<= 1.6.1"
+  s.add_dependency "rubocop", "<= 1.13.0"
   s.add_dependency "rubocop-performance", "<= 1.7.1"
   s.add_dependency "rubocop-rails", "<= 2.7.1"
 

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
   s.add_dependency "rubocop", "<= 1.13.0"
-  s.add_dependency "rubocop-performance", "<= 1.7.1"
+  s.add_dependency "rubocop-performance", "<= 1.11.0"
   s.add_dependency "rubocop-rails", "<= 2.7.1"
 
   s.add_development_dependency "actionview", "~> 5.0"


### PR DESCRIPTION
Version 1.4 of rubocop introduced a breaking change https://github.com/rubocop/rubocop/issues/7737 that creates some warnings and issues when using `parser/ruby27`, this issue was fixed in rubocop/rubocop#9702 and released in 1.13.0. 

This change will allow us to update to the latest rubocop when using this gem.

Closes https://github.com/github/rubocop-github/issues/77
