### PR TITLE
Require RuboCop 0.89 or higher

### DIFF
--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<= 1.13.0"
+  s.add_dependency "rubocop", ">= 0.89.0", "<= 1.13.0"
   s.add_dependency "rubocop-performance", "<= 1.11.0"
   s.add_dependency "rubocop-rails", "<= 2.7.1"
 


### PR DESCRIPTION
Follow https://github.com/github/rubocop-github/pull/73.

`Lint/BinaryOperatorWithIdenticalOperands` cop has introduced by RuboCop 0.89.0 and RuboCop GitHub uses the cop.
https://github.com/rubocop/rubocop/commit/d94c4a4a828c6e9acabf350df19555ccca3f26f5

This PR prevents the following error when using RuboCop 0.88 or lower.

```console
% bundle exec rake
(snip)

Running RuboCop...
Error: unrecognized cop Lint/BinaryOperatorWithIdenticalOperands found
in config/_default_shared.yml
RuboCop failed!
```