### PR TITLE
Remove references to html built via string operations in the styleguide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -403,19 +403,19 @@ STATES = %w(draft open closed)
 
 ``` ruby
 # bad (no interpolation needed)
-%(<div class="text">Some text</div>)
-# should be "<div class=\"text\">Some text</div>"
+%(Some text)
+# should be "Some text"
 
 # bad (no double-quotes)
 %(This is #{quality} style)
 # should be "This is #{quality} style"
 
 # bad (multiple lines)
-%(<div>\n<span class="big">#{exclamation}</span>\n</div>)
+%(one\ntwo\nthree)
 # should be a heredoc.
 
 # good (requires interpolation, has quotes, single line)
-%(<tr><td class="name">#{name}</td>)
+%(Hi, my name is "#{name}")
 ```
 
 * Use `%r` only for regular expressions matching *more than* one '/' character.
@@ -518,11 +518,11 @@ name = "Bozhidar"
 
 ``` ruby
 # good and also fast
-html = ""
-html << "<h1>Page title</h1>"
+text = ""
+text << Page title"
 
 paragraphs.each do |paragraph|
-  html << "<p>#{paragraph}</p>"
+  text << "\n#{paragraph}\n"
 end
 ```
 


### PR DESCRIPTION
While it's certainly possible to carefully construct HTML fragments with careful use of `html_safe`, we suggest that string operations should not be shown in examples where HTML is built. The safer approach to constructing HTML would be to use templates or tag helpers that automatically handle the context-aware and `html_safe`-aware APIs. 

So I took the approach of removing all HTML references to focus on what the rules are actually demonstrating. I could see an argument for converting the examples to use tag helpers but that would probably change the form and intent of these examples.

I am of the mindset that all code should be safe to copy/paste and while that is far from being true, it felt like a good idea to remove the anti-pattern shown in these examples.