### PR TITLE
Add support for rendering ViewComponents `with_content`

### DIFF
--- a/lib/rubocop/cop/github/render_literal_helpers.rb
+++ b/lib/rubocop/cop/github/render_literal_helpers.rb
@@ -28,6 +28,10 @@ module RuboCop
           (send nil? {:render :render_to_string} (send _ :new ...) ...)
         PATTERN
 
+        def_node_matcher :render_view_component_instance_with_content?, <<-PATTERN
+          (send nil? {:render :render_to_string} (send (send _ :new ...) `:with_content ...))
+        PATTERN
+
         def_node_matcher :render_view_component_collection?, <<-PATTERN
           (send nil? {:render :render_to_string} (send _ :with_collection ...) ...)
         PATTERN
@@ -41,7 +45,8 @@ module RuboCop
         end
 
         def render_view_component?(node)
-          render_view_component_instance?(node) ||
+          render_view_component_instance_with_content?(node) ||
+            render_view_component_instance?(node) ||
             render_view_component_collection?(node)
         end
       end

--- a/lib/rubocop/cop/github/render_literal_helpers.rb
+++ b/lib/rubocop/cop/github/render_literal_helpers.rb
@@ -20,10 +20,6 @@ module RuboCop
           (send nil? {:render :render_to_string} ({str sym} $_) $...)
         PATTERN
 
-        def_node_matcher :render_inst?, <<-PATTERN
-          (send nil? {:render :render_to_string} (send _ :new ...) ...)
-        PATTERN
-
         def_node_matcher :render_with_options?, <<-PATTERN
           (send nil? {:render :render_to_string} (hash $...) ...)
         PATTERN

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -62,6 +62,14 @@ class TestRailsViewRenderLiteral < CopTest
     assert_equal 0, cop.offenses.count
   end
 
+  def test_render_component_instance_with_content_no_offense
+    erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
+      <%= render MyClass.new(title: "foo", bar: "baz").with_content("foo") %>
+    ERB
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_render_component_instance_block_no_offense
     erb_investigate cop, <<-ERB, "app/views/foo/index.html.erb"
       <%= render Module::MyClass.new(title: "foo", bar: "baz") do %>Content<% end %>


### PR DESCRIPTION
This PR adds support for rendering ViewComponents `with_content`, which previously broke existing linters.