### PR TITLE
Remove version constraints for rubocop libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ test/tmp
 test/version_tmp
 tmp
 
-Gemfile.lock
-
 # YARD artifacts
 .yardoc
 _yardoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,84 @@
+PATH
+  remote: .
+  specs:
+    rubocop-github (0.16.2)
+      rubocop
+      rubocop-performance
+      rubocop-rails
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionview (5.2.6)
+      activesupport (= 5.2.6)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    ast (2.4.2)
+    builder (3.2.4)
+    concurrent-ruby (1.1.9)
+    crass (1.0.6)
+    erubi (1.10.0)
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    loofah (2.13.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    minitest (5.15.0)
+    nokogiri (1.13.1-x86_64-darwin)
+      racc (~> 1.4)
+    parallel (1.21.0)
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
+    racc (1.6.0)
+    rack (2.2.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.2)
+      loofah (~> 2.3)
+    rainbow (3.1.1)
+    rake (12.3.3)
+    regexp_parser (2.2.0)
+    rexml (3.2.5)
+    rubocop (1.24.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    rubocop-performance (1.13.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.13.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    ruby-progressbar (1.11.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    unicode-display_width (2.1.0)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  actionview (~> 5.0)
+  minitest (~> 5.14)
+  rake (~> 12.0)
+  rubocop-github!
+
+BUNDLED WITH
+   2.2.33

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "LICENSE", "config/*.yml", "lib/**/*.rb", "guides/*.md"]
 
-  s.add_dependency "rubocop", "<= 1.13.0"
-  s.add_dependency "rubocop-performance", "<= 1.11.0"
-  s.add_dependency "rubocop-rails", "<= 2.7.1"
+  s.add_dependency "rubocop"
+  s.add_dependency "rubocop-performance"
+  s.add_dependency "rubocop-rails"
 
   s.add_development_dependency "actionview", "~> 5.0"
   s.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
These constraints make it more difficult to upgrade these libraries in
projects that use rubocop-github.

I think the idea here was that we'd be able to bump the version
alongside the default config, but without locking to an exact version we
can still end up with a config that is incompatible with certain rubocop
version (see the unrecognized cop error in
https://github.com/github/rubocop-github/pull/86, for example).

If anything, I'd prefer a `>=` constraint over a `<=`. That would allow
us to bump the minimum constraint when we add new cops, but still
freely upgrade in our projects as long as there are no config
incompatibilities (which are less common anyway ever since RuboCop 1.0).