### PR TITLE
Bump all dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,17 +9,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (5.2.6)
-      activesupport (= 5.2.6)
+    actionview (6.1.4.4)
+      activesupport (= 6.1.4.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.6)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     builder (3.2.4)
     concurrent-ruby (1.1.9)
@@ -44,7 +45,7 @@ GEM
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
     rainbow (3.1.1)
-    rake (12.3.3)
+    rake (13.0.6)
     regexp_parser (2.2.0)
     rexml (3.2.5)
     rubocop (1.24.1)
@@ -66,18 +67,18 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  actionview (~> 5.0)
-  minitest (~> 5.14)
-  rake (~> 12.0)
+  actionview (~> 6.1)
+  minitest
+  rake
   rubocop-github!
 
 BUNDLED WITH

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop-performance"
   s.add_dependency "rubocop-rails"
 
-  s.add_development_dependency "actionview", "~> 5.0"
-  s.add_development_dependency "minitest", "~> 5.14"
-  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "actionview", "~> 6.1"
+  s.add_development_dependency "minitest"
+  s.add_development_dependency "rake"
 
   s.required_ruby_version = ">= 2.5.0"
 


### PR DESCRIPTION
This commit bumps all development dependencies, and removes pessimistic
version constraints where possible now that we've got a Gemfile.lock checked
in.

We had to keep the constraint for Rails for now, since Rails 7 is not
compatible with Ruby 2.6. We can bump Rails if we drop Ruby 2.6.

None of this affects the released gem, so as long as tests still pass we
are in good shape.