### PR TITLE
Fix .rubocop.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ gem "rubocop-rails", require: false
 ``` yaml
 inherit_gem:
   rubocop-github:
-    - config/default_edge.yml
-    - config/rails_edge.yml
+    - config/default.yml
+    - config/rails.yml
 ```
 
 ### Legacy usage


### PR DESCRIPTION
Following the changes in https://github.com/github/rubocop-github/pull/101 the example in the README currently refers to removed config files. This PR fixes that.