### PR TITLE
Separate Ruby (`rubocop-github`) from Rails (`rubocop-github-rails`) cops and rules to disambiguate rule inheritance from custom cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
-inherit_from: ./config/default.yml
+inherit_from:
+  - ./config/default.yml
 
 Naming/FileName:
   Enabled: true
   Exclude:
     - "rubocop-github.gemspec"
+    - "lib/rubocop-github.rb"
+    - "lib/rubocop-github-rails.rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     minitest (5.16.1)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -71,6 +73,7 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,32 @@ This repository provides recommended RuboCop configuration and additional Cops f
 
 ## Usage
 
-**Gemfile**
+Add `rubocop-github` to your Gemfile, along with its dependencies:
 
-``` ruby
-gem "rubocop-github"
-gem "rubocop-performance", require: false
-gem "rubocop-rails", require: false
-```
+  ```ruby
+  gem "rubocop-github", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  ```
 
-**.rubocop.yml**
+Inherit all of the stylistic rules and cops through an inheritance declaration in your `.rubocop.yml`:
 
-``` yaml
-inherit_gem:
-  rubocop-github:
-    - config/default.yml
-    - config/rails.yml
-```
+  ```yaml
+  # .rubocop.yml
+  inherit_from:
+    rubocop-github:
+      - config/default.yml # generic Ruby rules and cops
+      - config/rails.yml # Rails-specific rules and cops
+  ```
+
+Alternatively, only require the additional custom cops in your `.rubocop.yml` without inheriting/enabling the other stylistic rules:
+
+  ```yaml
+  # .rubocop.yml
+  require:
+    - rubocop-github  # generic Ruby cops only
+    - rubocop-github-rails # Rails-specific cops only
+  ```
 
 💭 Looking for `config/accessibility.yml` and the `GitHub/Accessibility` configs? They have been moved to [a new gem](https://github.com/github/rubocop-rails-accessibility).
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,5 @@
 require:
-  - rubocop/cop/github
+  - rubocop-github
   - rubocop-performance
 
 AllCops:

--- a/config/default_cops.yml
+++ b/config/default_cops.yml
@@ -1,0 +1,3 @@
+GitHub/InsecureHashAlgorithm:
+  Description: 'Encourage usage of secure hash algorithms'
+  Enabled: pending

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-github-rails
   - rubocop-rails
 
 Rails/OutputSafety:
@@ -22,63 +23,30 @@ GitHub/RailsApplicationRecord:
 
 GitHub/RailsControllerRenderActionSymbol:
   Enabled: true
-  Include:
-    - 'app/controllers/**/*.rb'
 
 GitHub/RailsControllerRenderLiteral:
   Enabled: true
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
-  Include:
-    - 'app/controllers/**/*.rb'
 
 GitHub/RailsControllerRenderPathsExist:
   Enabled: true
-  ViewPath:
-    - 'app/views'
-  Include:
-    - 'app/controllers/**/*.rb'
 
 GitHub/RailsControllerRenderShorthand:
   Enabled: true
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-shorthand.md
-  Include:
-    - 'app/controllers/**/*.rb'
 
 GitHub/RailsRenderInline:
   Enabled: true
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-inline.md
-  Include:
-    - 'app/controllers/**/*.rb'
-    - 'app/helpers/**/*.rb'
-    - 'app/view_models/**/*.rb'
-    - 'app/views/**/*.erb'
 
 GitHub/RailsRenderObjectCollection:
   Enabled: false
 
 GitHub/RailsViewRenderLiteral:
   Enabled: true
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
-  Include:
-    - 'app/helpers/**/*.rb'
-    - 'app/view_models/**/*.rb'
-    - 'app/views/**/*.erb'
 
 GitHub/RailsViewRenderPathsExist:
   Enabled: true
-  ViewPath:
-    - 'app/views'
-  Include:
-    - 'app/helpers/**/*.rb'
-    - 'app/view_models/**/*.rb'
-    - 'app/views/**/*.erb'
 
 GitHub/RailsViewRenderShorthand:
   Enabled: true
-  Include:
-    - 'app/helpers/**/*.rb'
-    - 'app/view_models/**/*.rb'
-    - 'app/views/**/*.erb'
 
 # Exclude Rails ERB files from incompatible cops
 

--- a/config/rails_cops.yml
+++ b/config/rails_cops.yml
@@ -1,0 +1,62 @@
+GitHub/RailsApplicationRecord:
+  Enabled: pending
+
+GitHub/RailsControllerRenderActionSymbol:
+  Enabled: pending
+  Include:
+    - 'app/controllers/**/*.rb'
+
+GitHub/RailsControllerRenderLiteral:
+  Enabled: pending
+  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
+  Include:
+    - 'app/controllers/**/*.rb'
+
+GitHub/RailsControllerRenderPathsExist:
+  Enabled: pending
+  ViewPath:
+    - 'app/views'
+  Include:
+    - 'app/controllers/**/*.rb'
+
+GitHub/RailsControllerRenderShorthand:
+  Enabled: pending
+  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-shorthand.md
+  Include:
+    - 'app/controllers/**/*.rb'
+
+GitHub/RailsRenderInline:
+  Enabled: pending
+  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-inline.md
+  Include:
+    - 'app/controllers/**/*.rb'
+    - 'app/helpers/**/*.rb'
+    - 'app/view_models/**/*.rb'
+    - 'app/views/**/*.erb'
+
+GitHub/RailsRenderObjectCollection:
+  Enabled: pending
+
+GitHub/RailsViewRenderLiteral:
+  Enabled: pending
+  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
+  Include:
+    - 'app/helpers/**/*.rb'
+    - 'app/view_models/**/*.rb'
+    - 'app/views/**/*.erb'
+
+GitHub/RailsViewRenderPathsExist:
+  Enabled: pending
+  ViewPath:
+    - 'app/views'
+  Include:
+    - 'app/helpers/**/*.rb'
+    - 'app/view_models/**/*.rb'
+    - 'app/views/**/*.erb'
+
+GitHub/RailsViewRenderShorthand:
+  Enabled: pending
+  Include:
+    - 'app/helpers/**/*.rb'
+    - 'app/view_models/**/*.rb'
+    - 'app/views/**/*.erb'

--- a/lib/rubocop-github-rails.rb
+++ b/lib/rubocop-github-rails.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/github"
+require "rubocop/github/inject"
+
+RuboCop::GitHub::Inject.rails_defaults!
+
+require "rubocop/cop/github/rails_application_record"
+require "rubocop/cop/github/rails_controller_render_action_symbol"
+require "rubocop/cop/github/rails_controller_render_literal"
+require "rubocop/cop/github/rails_controller_render_paths_exist"
+require "rubocop/cop/github/rails_controller_render_shorthand"
+require "rubocop/cop/github/rails_render_inline"
+require "rubocop/cop/github/rails_render_object_collection"
+require "rubocop/cop/github/rails_view_render_literal"
+require "rubocop/cop/github/rails_view_render_paths_exist"
+require "rubocop/cop/github/rails_view_render_shorthand"

--- a/lib/rubocop-github.rb
+++ b/lib/rubocop-github.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/github"
+require "rubocop/github/inject"
+
+RuboCop::GitHub::Inject.default_defaults!
+
+require "rubocop/cop/github/insecure_hash_algorithm"

--- a/lib/rubocop/cop/github.rb
+++ b/lib/rubocop/cop/github.rb
@@ -1,13 +1,4 @@
 # frozen_string_literal: true
 
-require "rubocop/cop/github/insecure_hash_algorithm"
-require "rubocop/cop/github/rails_application_record"
-require "rubocop/cop/github/rails_controller_render_action_symbol"
-require "rubocop/cop/github/rails_controller_render_literal"
-require "rubocop/cop/github/rails_controller_render_paths_exist"
-require "rubocop/cop/github/rails_controller_render_shorthand"
-require "rubocop/cop/github/rails_render_inline"
-require "rubocop/cop/github/rails_render_object_collection"
-require "rubocop/cop/github/rails_view_render_literal"
-require "rubocop/cop/github/rails_view_render_paths_exist"
-require "rubocop/cop/github/rails_view_render_shorthand"
+require "rubocop-github"
+require "rubocop-rails"

--- a/lib/rubocop/github.rb
+++ b/lib/rubocop/github.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module GitHub
+    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT = PROJECT_ROOT.join("config", "default_cops.yml").freeze
+    CONFIG_RAILS = PROJECT_ROOT.join("config", "rails_cops.yml").freeze
+  end
+end

--- a/lib/rubocop/github/inject.rb
+++ b/lib/rubocop/github/inject.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module GitHub
+    # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+    # bit of our configuration. Borrowed from:
+    # https://github.com/rubocop/rubocop-rails/blob/f36121946359615a26c9a941763abd1470693e8d/lib/rubocop/rails/inject.rb
+    module Inject
+      def self.default_defaults!
+        _load_config(CONFIG_DEFAULT)
+      end
+
+      def self.rails_defaults!
+        _load_config(CONFIG_RAILS)
+      end
+
+      def self._load_config(path)
+        path = path.to_s
+        hash = ConfigLoader.send(:load_yaml_configuration, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
+        puts "configuration from #{path}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, path, unset_nil: false)
+        ConfigLoader.instance_variable_set(:@default_configuration, config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates clearer distinctions between 

- opinionated **rule** configuration inheritance e.g. `inherit_from`, and
- custom **cops** and their default configuration, which can be separately `require:`'d

This also creates stronger separation between the generic-Ruby rules (e.g. `config/default.yml`) and the Rails-specific rules (e.g. `config/rails.yml`). I believe that will become necessary because of #119, because the current implementation requires _all_ the cops (Ruby _and Rails_) which means that they will all become Enabled/Pending (or whatever the *ByDefault is) even if the developer only wants the generic-Ruby rules. This PR makes it so that `default.yml` will only load/require the generic-Ruby cops and not all the Rails cops, and vice versa.

I followed the pattern used in `rubocop-rails` and `rubocop-performance` to [`inject!` Rubocop configuration/rules](https://github.com/rubocop/rubocop-performance/blob/3dd06b5c0a18fb9cea60e4ca0822cede9c716cb5/lib/rubocop/performance/inject.rb#L3-L18), along with their pattern of having [`Enabled: pending` status](https://github.com/rubocop/rubocop-performance/blob/3dd06b5c0a18fb9cea60e4ca0822cede9c716cb5/config/default.yml#L25). 

This should be fully backward compatible too and not require any changes by consumers.

Also, I learned a lot about how to package a Rubocop gem and plan to go suggest these changes too on [`rubocop-rails-accessibility`](https://github.com/github/rubocop-rails-accessibility) (though slightly differently because that gem is _just_ cops).