### PR TITLE
config/default: Link some rules to their styleguide justifications

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -65,8 +65,10 @@ Layout/BlockAlignment:
 Layout/BlockEndNewline:
   Enabled: true
 
+# TODO: Enable this since it's in the styleguide.
 Layout/CaseIndentation:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#indent-when-as-start-of-case
 
 Layout/ClassStructure:
   Enabled: false
@@ -186,10 +188,12 @@ Layout/IndentationStyle:
   Enabled: true
   EnforcedStyle: spaces
   IndentationWidth: 2
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#default-indentation
 
 Layout/IndentationWidth:
   Enabled: true
   Width: 2
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#default-indentation
 
 Layout/InitialIndentation:
   Enabled: true
@@ -259,9 +263,11 @@ Layout/SingleLineBlockChain:
 
 Layout/SpaceAfterColon:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAfterComma:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAfterMethodName:
   Enabled: true
@@ -271,12 +277,14 @@ Layout/SpaceAfterNot:
 
 Layout/SpaceAfterSemicolon:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAroundBlockParameters:
   Enabled: true
 
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-around-equals
 
 Layout/SpaceAroundKeyword:
   Enabled: false
@@ -311,6 +319,7 @@ Layout/SpaceInLambdaLiteral:
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
   EnforcedStyle: no_space
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-braces
 
 Layout/SpaceInsideArrayPercentLiteral:
   Enabled: true
@@ -341,6 +350,7 @@ Layout/TrailingEmptyLines:
 
 Layout/TrailingWhitespace:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#trailing-whitespace
 
 Lint/AmbiguousAssignment:
   Enabled: false
@@ -678,8 +688,10 @@ Lint/UnreachableCode:
 Lint/UnreachableLoop:
   Enabled: false
 
+# TODO: Enable this since it's in the styleguide.
 Lint/UnusedBlockArgument:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-around-equals
 
 Lint/UnusedMethodArgument:
   Enabled: false
@@ -976,8 +988,10 @@ Style/AccessorGrouping:
 Style/Alias:
   Enabled: false
 
+# TODO: Enable this since it's in the styleguide.
 Style/AndOr:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-and-or-or
 
 Style/ArgumentsForwarding:
   Enabled: false
@@ -1077,6 +1091,7 @@ Style/DateTime:
 
 Style/DefWithParentheses:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#method-parens-when-arguments
 
 Style/Dir:
   Enabled: false
@@ -1164,6 +1179,7 @@ Style/FloatDivision:
 
 Style/For:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#avoid-for
 
 Style/FormatString:
   Enabled: false
@@ -1201,6 +1217,7 @@ Style/HashLikeCase:
 Style/HashSyntax:
   Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#symbols-as-keys
 
 Style/HashTransformKeys:
   Enabled: false
@@ -1300,6 +1317,7 @@ Style/MultilineIfModifier:
 
 Style/MultilineIfThen:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-then-for-multi-line-if-unless
 
 Style/MultilineInPatternThen:
   Enabled: false
@@ -1475,8 +1493,10 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: false
 
+# TODO: Enable this since it's in the styleguide.
 Style/RedundantReturn:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#avoid-return
 
 Style/RedundantSelf:
   Enabled: false
@@ -1626,8 +1646,10 @@ Style/TrailingUnderscoreVariable:
 Style/TrivialAccessors:
   Enabled: false
 
+# TODO: Enable this since it's in the styleguide.
 Style/UnlessElse:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-else-with-unless
 
 Style/UnlessLogicalOperators:
   Enabled: false


### PR DESCRIPTION
- "Some of", yes, since there are a lot. But I thought I'd get started since this is an important step towards being able to a) enable more RuboCop rules based on the evidence of our styleguide, b) realising how far adrift our RuboCop configs have potentially become from what's written in the Styleguide, c) encouraging honest adoption of these rules across GitHub because they're actually justified in text.
