### PR TITLE
config/rails_cops: Update styleguide links now `master` => `main`

### DIFF
--- a/config/rails_cops.yml
+++ b/config/rails_cops.yml
@@ -8,7 +8,7 @@ GitHub/RailsControllerRenderActionSymbol:
 
 GitHub/RailsControllerRenderLiteral:
   Enabled: pending
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/guides/rails-render-literal.md
   Include:
     - 'app/controllers/**/*.rb'
 
@@ -21,13 +21,13 @@ GitHub/RailsControllerRenderPathsExist:
 
 GitHub/RailsControllerRenderShorthand:
   Enabled: pending
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-shorthand.md
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/guides/rails-controller-render-shorthand.md
   Include:
     - 'app/controllers/**/*.rb'
 
 GitHub/RailsRenderInline:
   Enabled: pending
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-controller-render-inline.md
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/guides/rails-controller-render-inline.md
   Include:
     - 'app/controllers/**/*.rb'
     - 'app/helpers/**/*.rb'
@@ -39,7 +39,7 @@ GitHub/RailsRenderObjectCollection:
 
 GitHub/RailsViewRenderLiteral:
   Enabled: pending
-  StyleGuide: https://github.com/github/rubocop-github/blob/master/guides/rails-render-literal.md
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/guides/rails-render-literal.md
   Include:
     - 'app/helpers/**/*.rb'
     - 'app/view_models/**/*.rb'


### PR DESCRIPTION
- GitHub will do the redirection for a bit (not sure exactly how long), but it's nice to make these a direct link rather than an onward hop.
