### PR TITLE
config/rails: Broader ERB exclude paths

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -34,27 +34,27 @@ GitHub/RailsViewRenderShorthand:
 
 Layout/BlockAlignment:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Layout/IndentationWidth:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Layout/InitialIndentation:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Layout/SpaceInsideParens:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Layout/TrailingEmptyLines:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Layout/TrailingWhitespace:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Lint/UselessAccessModifier:
   ContextCreatingMethods:
@@ -399,16 +399,16 @@ Rails/WhereNot:
 
 Style/For:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Style/OneLineConditional:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Style/Semicolon:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"
 
 Style/StringLiterals:
   Exclude:
-    - app/views/**/*.erb
+    - "**/*.erb"


### PR DESCRIPTION
- Yes, by default Rails has `app/views/**/*.erb`, but ERB can also be elsewhere in the codebase.
- This avoids users (of the Rails configs of this gem) from having to manually add other ERB exclusions, since these cops don't reliably play nicely with any ERB regardless of where it lives.
