### PR TITLE
config/default: Remove some redundant `Enabled: true` for cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -182,16 +182,14 @@ Layout/HeredocIndentation:
   Enabled: false
 
 Layout/IndentationConsistency:
-  Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#indentation
 
 Layout/IndentationStyle:
-  Enabled: true
   EnforcedStyle: spaces
   IndentationWidth: 2
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#default-indentation
 
 Layout/IndentationWidth:
-  Enabled: true
   Width: 2
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#default-indentation
 
@@ -262,11 +260,9 @@ Layout/SingleLineBlockChain:
   Enabled: false
 
 Layout/SpaceAfterColon:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAfterComma:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAfterMethodName:
@@ -276,18 +272,16 @@ Layout/SpaceAfterNot:
   Enabled: true
 
 Layout/SpaceAfterSemicolon:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAroundBlockParameters:
   Enabled: true
 
 Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-around-equals
 
 Layout/SpaceAroundKeyword:
-  Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceAroundMethodCallOperator:
   Enabled: false
@@ -317,7 +311,6 @@ Layout/SpaceInLambdaLiteral:
   Enabled: false
 
 Layout/SpaceInsideArrayLiteralBrackets:
-  Enabled: true
   EnforcedStyle: no_space
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-braces
 
@@ -349,7 +342,6 @@ Layout/TrailingEmptyLines:
   Enabled: true
 
 Layout/TrailingWhitespace:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#trailing-whitespace
 
 Lint/AmbiguousAssignment:
@@ -1090,7 +1082,6 @@ Style/DateTime:
   Enabled: false
 
 Style/DefWithParentheses:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#method-parens-when-arguments
 
 Style/Dir:
@@ -1178,7 +1169,6 @@ Style/FloatDivision:
   Enabled: false
 
 Style/For:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#avoid-for
 
 Style/FormatString:
@@ -1215,7 +1205,6 @@ Style/HashLikeCase:
   Enabled: false
 
 Style/HashSyntax:
-  Enabled: true
   EnforcedStyle: ruby19_no_mixed_keys
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#symbols-as-keys
 
@@ -1316,7 +1305,6 @@ Style/MultilineIfModifier:
   Enabled: false
 
 Style/MultilineIfThen:
-  Enabled: true
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-then-for-multi-line-if-unless
 
 Style/MultilineInPatternThen:
@@ -1583,8 +1571,8 @@ Style/StringHashKeys:
   Enabled: false
 
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#double-quotes
 
 Style/StringLiteralsInInterpolation:
   Enabled: false


### PR DESCRIPTION
- For cops with a styleguide link, where there's evidence that we want the rule to apply, we don't need to also explicitly declare `Enabled: true` for each of them. Since we removed `DisabledByDefault`, the enablements here for cops that are *enabled by default in RuboCop itself** are redundant.
- I could have gone further and removed the rules that RuboCop has enabled by default that _didn't_ have a styleguide link, but I feel like we need some evidence for why a rule is in place first for when people come looking at this gem's config to figure out why new rules are suddenly failing or not.
