### PR TITLE
config/default: Enable `Lint/ParenthesesAsGroupedExpression`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -561,7 +561,9 @@ Lint/OutOfRangeRegexpRef:
   Enabled: false
 
 Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-method-parens
+  Exclude:
+  - "**/*.erb"
 
 Lint/PercentStringArray:
   Enabled: false


### PR DESCRIPTION
- All offenses for non-ERB files were fixed in `github/github`, so it's not too much churn to enable this here. It's enabled by default in RuboCop itself, so here we can remove the `Enabled: false`, add a `StyleGuide` link, and exclude ERB files since the autocorrector hates them.