### PR TITLE
Fix usage documentation for Inheriting all rules and cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Inherit all of the stylistic rules and cops through an inheritance declaration i
 
   ```yaml
   # .rubocop.yml
-  inherit_from:
+  inherit_gem:
     rubocop-github:
-      - config/default.yml # generic Ruby rules and cops
-      - config/rails.yml # Rails-specific rules and cops
+    - config/default.yml # generic Ruby rules and cops
+    - config/rails.yml # Rails-specific rules and cops
   ```
 
 Alternatively, only require the additional custom cops in your `.rubocop.yml` without inheriting/enabling the other stylistic rules:


### PR DESCRIPTION
This PR just updating the documentation for Inheriting all rules and cops


### background

According to the [current documentation](https://github.com/github/rubocop-github#usage), I need to do the following to bring all of the rules

```yaml
# .rubocop.yml
inherit_from:
  rubocop-github:
    - config/default.yml # generic Ruby rules and cops
    - config/rails.yml # Rails-specific rules and cops
```

When I tried to add these lines at .rubocop.yml, I got the following error:

```
➜   git:(add-github-rubocop) ✗ bundle exec rubocop
no implicit conversion of Array into String
/Users/codeminator/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-1.39.0/lib/rubocop/config_loader_resolver.rb:239:in `match?'
/Users/codeminator/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-1.39.0/lib/rubocop/config_loader_resolver.rb:239:in `remote_file?'
/Users/codeminator/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-1.39.0/lib/rubocop/config_loader_resolver.rb:217:in `inherited_file'
/Users/codeminator/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rubocop-1.39.0/lib/rubocop/config_loader_resolver.rb:210:in `block in base_configs'
...
...
```

But when I tried the changed code introduced at this PR, it works fine.

