### PR TITLE
Improve check for hash literals

### DIFF
--- a/lib/rubocop/cop/github/render_literal_helpers.rb
+++ b/lib/rubocop/cop/github/render_literal_helpers.rb
@@ -41,7 +41,8 @@ module RuboCop
         PATTERN
 
         def hash_with_literal_keys?(hash)
-          hash.pairs.all? { |pair| literal?(pair.key) }
+          hash.children.all? { |child| child.pair_type? } &&
+            hash.pairs.all? { |pair| literal?(pair.key) }
         end
 
         def render_view_component?(node)

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -442,6 +442,17 @@ class TestRailsControllerRenderLiteral < CopTest
     assert_equal 1, offenses.count
   end
 
+  def test_render_literal_splat_locals_offense
+    offenses = investigate cop, <<-RUBY, "app/controllers/products_controller.rb"
+      class ProductsController < ActionController::Base
+        def index
+          render "products/product", locals: { **locals }
+        end
+      end
+    RUBY
+
+    assert_equal 1, offenses.count
+  end
 
   def test_render_literal_dynamic_local_key_offense
     offenses = investigate cop, <<-RUBY, "app/controllers/products_controller.rb"

--- a/test/test_rails_view_render_literal.rb
+++ b/test/test_rails_view_render_literal.rb
@@ -145,6 +145,14 @@ class TestRailsViewRenderLiteral < CopTest
     assert_equal 1, offenses.count
   end
 
+  def test_render_literal_splat_locals_offense
+    offenses = erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render "products/product", { **locals } %>
+    ERB
+
+    assert_equal 1, offenses.count
+  end
+
   def test_render_options_static_locals_no_offense
     offenses = erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
       <%= render partial: "products/product", locals: { product: product } %>
@@ -164,6 +172,14 @@ class TestRailsViewRenderLiteral < CopTest
   def test_render_options_dynamic_local_key_offense
     offenses = erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
       <%= render partial: "products/product", locals: { product_key => product } %>
+    ERB
+
+    assert_equal 1, offenses.count
+  end
+
+  def test_render_options_local_splat_offense
+    offenses = erb_investigate cop, <<-ERB, "app/views/products/index.html.erb"
+      <%= render partial: "products/product", locals: { **locals } %>
     ERB
 
     assert_equal 1, offenses.count


### PR DESCRIPTION
Previously this linter was possible to circumvent by using splats.