### PR TITLE
Set required_ruby_version to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Update Gemspec `required_ruby_version to `>= 3.0.0`
+- Update Gemspec `required_ruby_version` to `>= 3.0.0`
 
 ## v0.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update Gemspec `required_ruby_version to `>= 3.0.0`
+
 ## v0.21.0
 
 - Added new GitHub/AvoidObjectSendWithDynamicMethod cop to discourage use of methods like Object#send

--- a/rubocop-github.gemspec
+++ b/rubocop-github.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest"
   s.add_development_dependency "rake"
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.email = "engineering@github.com"
   s.authors = "GitHub"


### PR DESCRIPTION
With https://github.com/github/rubocop-github/pull/146, the `required_ruby_version` should probably match what we test.