### PR TITLE
Add grouped Dependabot updates for Bundler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,20 @@ updates:
   versioning-strategy: increase
   schedule:
     interval: weekly
+      open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "all"
+    groups:
+      bundler-rubocop:
+        patterns:
+          - "rubocop*"
+      bundler-all:
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - "rubocop*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
Separates the `rubocop*` updates into their own group, to hopefully make it easier to merge the non-Rubocop updates.