### PR TITLE
`RuboCop::Cop::GitHub::RailsControllerRenderLiteral`: Make error message helpful for `locals` offence

### DIFF
--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -11,6 +11,8 @@ module RuboCop
 
         MSG = "render must be used with a string literal or an instance of a Class"
 
+        LOCALS_MSG = "render must be used with a hash literal for the locals keyword argument"
+
         def_node_matcher :ignore_key?, <<-PATTERN
           (pair (sym {
             :body
@@ -99,7 +101,7 @@ module RuboCop
           if option_pairs
             locals = option_pairs.map { |pair| locals_key?(pair) }.compact.first
             if locals && (!locals.hash_type? || !hash_with_literal_keys?(locals))
-              add_offense(node)
+              add_offense(node, message: LOCALS_MSG)
             end
           end
         end

--- a/lib/rubocop/cop/github/rails_controller_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_controller_render_literal.rb
@@ -9,9 +9,7 @@ module RuboCop
       class RailsControllerRenderLiteral < Base
         include RenderLiteralHelpers
 
-        MSG = "render must be used with a string literal or an instance of a Class"
-
-        LOCALS_MSG = "render must be used with a hash literal for the locals keyword argument"
+        MSG = "render must be used with a string literal or an instance of a Class, and use literals for locals keys"
 
         def_node_matcher :ignore_key?, <<-PATTERN
           (pair (sym {
@@ -101,7 +99,7 @@ module RuboCop
           if option_pairs
             locals = option_pairs.map { |pair| locals_key?(pair) }.compact.first
             if locals && (!locals.hash_type? || !hash_with_literal_keys?(locals))
-              add_offense(node, message: LOCALS_MSG)
+              add_offense(node)
             end
           end
         end

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -274,7 +274,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_implicit_with_layout_offense
@@ -287,7 +289,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_implicit_with_status_offense
@@ -300,7 +304,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_variable_offense
@@ -313,7 +319,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_to_string_variable_offense
@@ -326,7 +334,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_action_variable_offense
@@ -339,7 +349,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_template_variable_offense
@@ -352,7 +364,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_partial_variable_offense
@@ -365,7 +379,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_template_with_layout_variable_offense
@@ -378,7 +394,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_template_variable_with_layout_offense
@@ -391,7 +409,9 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
+    assert_equal \
+      "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys",
+      offenses[0].message
   end
 
   def test_render_shorthand_static_locals_no_offsense

--- a/test/test_rails_controller_render_literal.rb
+++ b/test/test_rails_controller_render_literal.rb
@@ -274,7 +274,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_implicit_with_layout_offense
@@ -287,7 +287,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_implicit_with_status_offense
@@ -300,7 +300,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_variable_offense
@@ -313,7 +313,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_to_string_variable_offense
@@ -326,7 +326,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_action_variable_offense
@@ -339,7 +339,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_template_variable_offense
@@ -352,7 +352,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_partial_variable_offense
@@ -365,7 +365,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_template_with_layout_variable_offense
@@ -378,7 +378,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_template_variable_with_layout_offense
@@ -391,7 +391,7 @@ class TestRailsControllerRenderLiteral < CopTest
     RUBY
 
     assert_equal 1, offenses.count
-    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class", offenses[0].message
+    assert_equal "#{cop.name}: render must be used with a string literal or an instance of a Class, and use literals for locals keys", offenses[0].message
   end
 
   def test_render_shorthand_static_locals_no_offsense


### PR DESCRIPTION
The current message "render must be used with a string literal or an instance of a Class" is not helpful when you are passing a string literal, but the cop is really complaining about the `locals` keyword argument not using literals.

This makes the message helpful in that situation.
