### PR TITLE
Remove "rubygems: latest" from setup-ruby workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,5 @@ jobs:
         uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf
         with:
           bundler-cache: true
-          rubygems: latest
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
The latest rubygems is not compatible with Ruby 3.0.