### PR TITLE
Allow explicit self in STYLEGUIDE.md

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -252,22 +252,6 @@ class SomeClass
 end
 ```
 
-* Avoid explicit use of `self` as the recipient of internal class or instance
-  messages unless to specify a method shadowed by a variable.
-  <a name="self-messages"></a><sup>[[link](#self-messages)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#styleredundantself">RuboCop rule: Style/RedundantSelf</a>
-
-``` ruby
-class SomeClass
-  attr_accessor :message
-
-  def greeting(name)
-    message = "Hi #{name}" # local variable in Ruby, not attribute writer
-    self.message = message
-  end
-end
-```
-
 ## Collections
 
 * Prefer `%w` to the literal array syntax when you need an array of


### PR DESCRIPTION
Hey there!

I just got pinged for @sampart's [PR here](https://github.com/github/github/pull/357331/) where explicit self was being auto-removed from the codebase, and I experienced a negative reaction to it.

As a means of discussion, this PR proposes removing the `avoid explicit use of self` rule – but I don't think I actually care about it as a styleguide preference per se, but I feel like I do disagree with it being auto-enforced.

Here is my reasoning:

As the styleguide suggests, _sometimes you need to explicitly refer to `self`_, i.e. "unless to specify a method shadowed by a variable". Sometime in the distant past, earlier in my career, I got bit by variable shadowing: I updated a local variable instead of referencing a class method, and introduced a bug.

Ever since then I have adopted a defensive posture: whenever I am referring to a classes' method, or for example, an ActiveRecord attribute, **I always explicitly use `self.foo`**. By _always_ being explicit, it is impossible to accidentally, later on, in an unrelated change, introduce a bug because a variable got shadowed. In some of these code we work on it's simply impossible for every developer to know every class method.

OK Phill, you might say, but why does this matter? Just because you've developed trauma-informed behaviours doesn't mean it's a concern for the rest of us.

Here's the kicker for making it auto-enforced: if you almost always get dinged by the linter, after you've written the code, for using `self.` you will reflexively adopt the opposite stance and avoid `self.` as much as possible. This means that when you do actually shadow a variable you might be less likely to pick it up. It imposes a cognitive burden on the developer.[^semi-colons]

[^semi-colons]: An analogy here might be making semi-colons optional in pure Javascript. Yes, it works, except in occasions where it introduces a bug. So to support removing semi-colons, you need to be perfectly aware of the edge cases where it introduces a bug. That sounds a lot harder than just using semi-colons!

(If I were god-empress of the world, I'd go the full other direction and suggest enforcing _always using explicit self_ as a means of removing this class of bug altogether, but here I would be satisfied by simply not making MY life more annoying 😉.)

tl;dr:
- enforcing implicit self does not catch bugs or improve performance
- enforcing implicit self can, occasionally, introduce bugs
- i reflexively always use explicit self and this would impose a burden on me personally, which we can all agree is a great tragedy

Thank you kindly for your time & consideration,