### PR TITLE
Enable `Layout/SpaceInsideHashLiteralBraces`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -331,7 +331,8 @@ Layout/SpaceInsideBlockBraces:
   Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
+  Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceInsideParens:
   Enabled: true

--- a/test/test_insecure_hash_algorithm.rb
+++ b/test/test_insecure_hash_algorithm.rb
@@ -10,7 +10,7 @@ class TestInsecureHashAlgorithm < CopTest
   end
 
   def make_cop(allowed:)
-    config = RuboCop::Config.new({"GitHub/InsecureHashAlgorithm" => {"Allowed" => allowed}})
+    config = RuboCop::Config.new({ "GitHub/InsecureHashAlgorithm" => { "Allowed" => allowed } })
     cop_class.new(config)
   end
 


### PR DESCRIPTION
- This is part of our styleguide and was enabled in `github/github` in 2022, so let's make it the default.