### PR TITLE
Attest Build Provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -37,13 +39,17 @@ jobs:
       - name: build
         run: echo "GEM_VERSION=$(gem build ${{ env.GEM_NAME }}.gemspec 2>&1 | grep Version | cut -d':' -f 2 | tr -d " \t\n\r")" >> $GITHUB_ENV
 
+      - uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # pin@v2
+        with:
+          subject-path: "${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem"
+
       - name: publish to GitHub packages
         run: |
           export OWNER=$( echo ${{ github.repository }} | cut -d "/" -f 1 )
           GEM_HOST_API_KEY=${{ secrets.GITHUB_TOKEN }} gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} ${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem
 
       - name: release
-        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # pin@v1.14.0
+        uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # pin@v1.15.0
         with:
           artifacts: "${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem"
           tag: "v${{ env.GEM_VERSION }}"


### PR DESCRIPTION
# Attest Build Provenance :lock:

> _Artifact attestations enable you to increase the supply chain security of your builds by establishing where and how your software was built._

This pull request publishes build attestations for the `rubocop-github` Gem. This allows us and all downstream consumers to use the built in gh cli command to securely validate when/where the Gem was built and that GitHub (the trusted source) created it.

## Example :camera_flash:

Here is an example of how users of this gem can verify the gem after this PR lands:

```console
$ gh attestation verify rubocop-github-X.X.X.gem --owner github
```

> Read more about artifact attestations [here](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) :books: