### PR TITLE
Fix variable naming in `Rails/ViewRenderLiteral`

### DIFF
--- a/lib/rubocop/cop/github/rails_view_render_literal.rb
+++ b/lib/rubocop/cop/github/rails_view_render_literal.rb
@@ -54,7 +54,7 @@ module RuboCop
 
           if render_literal?(node) && node.arguments.count > 1
             locals = node.arguments[1]
-          elsif options_pairs = render_with_options?(node)
+          elsif option_pairs = render_with_options?(node)
             locals = option_pairs.map { |pair| locals_key?(pair) }.compact.first
           end
 


### PR DESCRIPTION
- Fixes https://github.com/github/rubocop-github/security/code-scanning/4 and https://github.com/github/rubocop-github/security/code-scanning/5 by fixing the typo for singular vs. plural `option_pairs` vs. `options_pairs`.