### PR TITLE
Bump to version 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rubocop-github
 
+## v0.25.0
+
+- Read the automatic release notes on [the /releases page for this gem](https://github.com/github/rubocop-github/releases).
+- Updated related gems
+- Specify plugin class names for included rubocop plugins
+
+## v0.24.0
+
+- Read the automatic release notes on [the /releases page for this gem](https://github.com/github/rubocop-github/releases).
+
 ## v0.23.0
 
 - Read the automatic release notes on [the /releases page for this gem](https://github.com/github/rubocop-github/releases).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-github (0.24.0)
+    rubocop-github (0.25.0)
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.23)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-VERSION = "0.24.0"
+VERSION = "0.25.0"


### PR DESCRIPTION
Bumped the version number, ran `bundle install` and added some release notes for 0.24.0 and 0.25.0