### PR TITLE
Document `.descendants` and `.subclasses` advice

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1096,4 +1096,24 @@ If you need to call a subview that expects an instance variable be set. If possi
 
 Unfortunately the only way to get data into a layout template is with instance variables. You can't explicitly pass locals to them.
 
+
+### Avoid `Class#descendants` and `Class#subclasses`
+
+Avoid using `Class#descendants` and `Class#subclasses` as they are unreliable for several reasons:
+
+* They don't know about classes that haven't been autoloaded yet
+* They're non-deterministic with regards to garbage collection of classes. If you use `Class#descendants` or `Class#subclasses` in tests, where there is a pattern to dynamically define classes, GC is unpredictable for when those classes are cleaned up and removed by the GC.
+
+```ruby
+# bad
+class Person < ApplicationRecord
+end
+
+class Employee < Person
+end
+
+Person.descendants # => Unreliable, may or may not include Employee
+Person.subclasses  # => Unreliable, may or may not include Employee
+```
+
 [rubocop-guide]: https://github.com/rubocop-hq/ruby-style-guide


### PR DESCRIPTION
A wise man, let's call him Ben, [once said](https://github.com/github/rubocop-github/issues/110#issue-1328950245):

> There are two reasons why this is an unreliable solution:
> 
> - it doesn't know about things that have yet to be autoloaded
> 
> - it's non-deterministic with regards to Garbage Collection of classes. If you use `Class.descendants` in Test, where there is a pattern to dynamically define classes, GC is unpredictable for when those classes are cleaned up and removed by the GC.

And I totally trust him on that because he's making a… GoodJob :drum: 

This is generally unwanted to be documented in Rails.
But I also understand Ben's reasoning.

Now the question is: do you want to have it here?
And if so: would you also like to have complementary cops (i.e. like [1](https://github.com/rubocop/rubocop/pull/14620/files), [2](https://github.com/rubocop/rubocop-rails/pull/1545/files)) here? :thinking: 

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev