### PR TITLE
Complete RuboCop style guide links

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -478,7 +478,7 @@ remove_member(user, skip_membership_check: true)
 
 * Use `snake_case` for methods and variables.
   <a name="snake-case-methods-vars"></a><sup>[[link](#snake-case-methods-vars)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_naming.html#namingsnakecase">RuboCop rule: Naming/SnakeCase</a>
+  * <a href="https://docs.rubocop.org/rubocop/cops_naming.html#namingmethodname">RuboCop rule: Naming/MethodName</a>
   * <a href="https://docs.rubocop.org/rubocop/cops_naming.html#namingvariablename">RuboCop rule: Naming/VariableName</a>
 
 * Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP,
@@ -493,7 +493,7 @@ remove_member(user, skip_membership_check: true)
 * The names of predicate methods (methods that return a boolean value)
   should end in a question mark. (i.e. `Array#empty?`).
   <a name="bool-methods-qmark"></a><sup>[[link](#bool-methods-qmark)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_naming.html#namingpredicatename">RuboCop rule: Naming/PredicateName</a>
+  * <a href="https://docs.rubocop.org/rubocop/cops_naming.html#namingpredicateprefix">RuboCop rule: Naming/PredicatePrefix</a>
 
 * The names of potentially "dangerous" methods (i.e. methods that modify `self` or the
   arguments, `exit!`, etc.) should end with an exclamation mark. Bang methods
@@ -718,7 +718,7 @@ end
 * Favor modifier `if/unless` usage when you have a single-line
   body.
   <a name="favor-modifier-if-unless"></a><sup>[[link](#favor-modifier-if-unless)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#stylemultilineternaryoperator">RuboCop rule: Style/MultilineTernaryOperator</a>
+  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#styleifunlessmodifier">RuboCop rule: Style/IfUnlessModifier</a>
 
 ``` ruby
 # bad
@@ -788,7 +788,7 @@ end
   trivial. However, do use the ternary operator(`?:`) over `if/then/else/end` constructs
   for single line conditionals.
   <a name="trivial-ternary"></a><sup>[[link](#trivial-ternary)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#stylemultilineternaryoperator">RuboCop rule: Style/MultilineTernaryOperator</a>
+  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#styleonelineconditional">RuboCop rule: Style/OneLineConditional</a>
 
 ``` ruby
 # bad
@@ -878,7 +878,7 @@ end
 
 * Use spaces around the `=` operator when assigning default values to method parameters:
   <a name="spaces-around-equals"></a><sup>[[link](#spaces-around-equals)]</sup>
-  * <a href="https://docs.rubocop.org/rubocop/cops_style.html#stylespacearoundequalsinparameterdefault">RuboCop rule: Style/SpaceAroundEqualsInParameterDefault</a>
+  * <a href="https://docs.rubocop.org/rubocop/cops_layout.html#layoutspacearoundequalsinparameterdefault">RuboCop rule: Layout/SpaceAroundEqualsInParameterDefault</a>
 
 ``` ruby
 # bad

--- a/config/default.yml
+++ b/config/default.yml
@@ -287,6 +287,7 @@ Layout/SpaceAfterMethodName:
 
 Layout/SpaceAfterNot:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-bang
 
 Layout/SpaceAfterSemicolon:
   StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
@@ -311,6 +312,7 @@ Layout/SpaceAroundOperators:
 
 Layout/SpaceBeforeBlockBraces:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#spaces-operators
 
 Layout/SpaceBeforeBrackets:
   Enabled: false
@@ -346,6 +348,7 @@ Layout/SpaceInsideHashLiteralBraces:
 
 Layout/SpaceInsideParens:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-braces
 
 Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
@@ -355,6 +358,7 @@ Layout/SpaceInsideRangeLiteral:
 
 Layout/SpaceInsideReferenceBrackets:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-spaces-braces
 
 Layout/SpaceInsideStringInterpolation:
   Enabled: false
@@ -825,12 +829,14 @@ Naming/MemoizedInstanceVariableName:
 
 Naming/MethodName:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#snake-case-methods-vars
 
 Naming/MethodParameterName:
   Enabled: false
 
 Naming/PredicatePrefix:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#bool-methods-qmark
 
 Naming/RescuedExceptionsVariableName:
   Enabled: false
@@ -1269,6 +1275,7 @@ Style/IfInsideElse:
 
 Style/IfUnlessModifier:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#favor-modifier-if-unless
 
 Style/IfUnlessModifierOfIfUnless:
   Enabled: false
@@ -1369,6 +1376,7 @@ Style/MultilineMethodSignature:
 
 Style/MultilineTernaryOperator:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-multiline-ternary
 
 Style/MultilineWhenThen:
   Enabled: false
@@ -1442,6 +1450,7 @@ Style/ObjectThen:
 
 Style/OneLineConditional:
   Enabled: true
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#trivial-ternary
 
 Style/OpenStructUse:
   Enabled: false
@@ -1454,6 +1463,7 @@ Style/OptionalArguments:
 
 Style/OptionalBooleanParameter:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#keyword-arguments
 
 Style/OrAssignment:
   Enabled: true
@@ -1466,6 +1476,7 @@ Style/ParallelAssignment:
 
 Style/ParenthesesAroundCondition:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#no-parens-if-unless-while
 
 Style/PercentLiteralDelimiters:
   Enabled: false
@@ -1628,6 +1639,7 @@ Style/StringChars:
 
 Style/StringConcatenation:
   Enabled: false
+  StyleGuide: https://github.com/github/rubocop-github/blob/main/STYLEGUIDE.md#string-interpolation
 
 Style/StringHashKeys:
   Enabled: false


### PR DESCRIPTION
## Summary

- update outdated or mismatched RuboCop rule references in the style guide
- add the remaining local `StyleGuide` links to the corresponding current cop configuration

## Why

Several guide rules either lacked local metadata in `config/default.yml` or still referenced cops that have since been renamed. Completing the mapping makes RuboCop's cop details point users back to the matching project guidance without changing any cop behavior.

Fixes #133.

## Validation

- focused guide/config mapping check: 60 mappings, 55 unique cops, 0 missing
- `bundle exec rake test` (123 runs, 177 assertions)
- `bundle exec rubocop` (31 files, no offenses)
- `bundle exec rake`
- `git diff --check`
